### PR TITLE
Use tox

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,3 +1,4 @@
 # Requirements needed to develop the application
 -r test.txt
 pre-commit==1.18.2
+tox==3.13.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,13 +7,3 @@ multi_line_output = 3
 include_trailing_comma = True
 use_parentheses = True
 line_length = 88
-
-[tox:tox]
-envlist = py27, py37
-
-[tox:testenv]
-deps =
-    -r{toxinidir}/requirements/test.txt
-commands =
-    flake8 setup.py src tests docs
-    pytest tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,13 @@ multi_line_output = 3
 include_trailing_comma = True
 use_parentheses = True
 line_length = 88
+
+[tox:tox]
+envlist = py27, py37
+
+[tox:testenv]
+deps =
+    -r{toxinidir}/requirements/test.txt
+commands =
+    flake8 setup.py src tests docs
+    pytest tests

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,9 @@
+[tox]
+envlist = py27, py37
+
+[testenv]
+deps =
+    -r{toxinidir}/requirements/test.txt
+commands =
+    flake8 setup.py src tests docs
+    pytest tests


### PR DESCRIPTION
Add [tox](https://tox.readthedocs.io/en/latest/) requirement and configuration file.

This is only to allow using tox in the development environment to be able to run tests for both python2 and python3 easily without the need to execute them in the CI environment.