### PR TITLE
Add jinja2 to INSTALL_REQUIRES

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
         return input_file.read()
 
 
-INSTALL_REQUIRES = ["click", "click-default-group", "dicttoxml", "requests"]
+INSTALL_REQUIRES = ["click", "click-default-group", "dicttoxml", "jinja2", "requests"]
 
 setup(
     name="greynoise",


### PR DESCRIPTION
Add `jinja2` to `INSTALL_REQUIRES` in setup.py to address the problem during the execution of `setup.install`

Fixes #56 