### PR TITLE
Use user agent header

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,7 +25,7 @@ copyright = "2018-2019, GreyNoise Intelligence"
 author = "GreyNoise Intelligence"
 
 # The full version, including alpha/beta/rc tags
-release = "0.1.5"
+release = "0.2.0"
 
 
 # -- General configuration ---------------------------------------------------

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,6 @@
 # Requirements needed to develop the application
 -r test.txt
+bumpversion==0.5.3
 ipython==7.7.0;python_version>='3'
 pre-commit==1.18.2
 tox==3.13.2

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,20 @@
+[bumpversion]
+current_version = 0.2.0
+tag = True
+commit = True
+
+[bumpversion:file:setup.py]
+search = version="{current_version}"
+replace = version="{new_version}"
+
+[bumpversion:file:src/greynoise/api.py]
+search = CLIENT_VERSION = "{current_version}"
+replace = CLIENT_VERSION = "{new_version}"
+
+[bumpversion:file:docs/source/conf.py]
+search = release = "{current_version}"
+replace = release = "{new_version}"
+
 [flake8]
 max-line-length = 88
 max-complexity = 10
@@ -10,3 +27,4 @@ line_length = 88
 
 [tool:pytest]
 addopts = --pdbcls=IPython.terminal.debugger:TerminalPdb
+

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 88
-#max-complexity = 10
+max-complexity = 10
 
 [isort]
 multi_line_output = 3

--- a/src/greynoise/api.py
+++ b/src/greynoise/api.py
@@ -80,7 +80,7 @@ class GreyNoise(object):
         if params is None:
             params = {}
         headers = {
-            "X-Request-Client": "pyGreyNoise v{}".format(self.CLIENT_VERSION),
+            "User-Agent": "greyNoise/{}".format(self.CLIENT_VERSION),
             "key": self.api_key,
         }
         url = "/".join([self.BASE_URL, self.API_VERSION, endpoint])

--- a/src/greynoise/api.py
+++ b/src/greynoise/api.py
@@ -23,7 +23,7 @@ class GreyNoise(object):
 
     NAME = "GreyNoise"
     BASE_URL = "https://enterprise.api.greynoise.io"
-    CLIENT_VERSION = 1
+    CLIENT_VERSION = "0.2.0"
     API_VERSION = "v2"
     EP_GNQL = "experimental/gnql"
     EP_GNQL_STATS = "experimental/gnql/stats"


### PR DESCRIPTION
API client now sends its version number in the User-Agent header (instead of in the X-Request-Client one).

Version numbers for the library, the client and the documentation now match.

Bumpversion tool has been added to keep track of version numbers.