### PR TITLE
GNQL stats output columnar

### DIFF
--- a/src/greynoise/cli/templates/gnql_stats.txt.j2
+++ b/src/greynoise/cli/templates/gnql_stats.txt.j2
@@ -1,55 +1,41 @@
+{% import "macros.txt.j2" as macros %}
+
 {%- if gnql_stats.stats.actors %}
 Actors:
-{%- for actor in gnql_stats.stats.actors %}
-- {{ actor.actor }}: {{ actor.count }}
-{%- endfor %}
-{% endif %}
+{{- macros.column_list(gnql_stats.stats.actors, "actor") }}
+{%- endif %}
 
 {%- if gnql_stats.stats.asns %}
 ASNs:
-{%- for asn in gnql_stats.stats.asns %}
-- {{ asn.asn }}: {{ asn.count }}
-{%- endfor %}
-{% endif %}
+{{- macros.column_list(gnql_stats.stats.asns, "asn") }}
+{%- endif %}
 
 {%- if gnql_stats.stats.categories %}
 Categories:
-{%- for category in gnql_stats.stats.categories %}
-- {{ category.category }}: {{ category.count }}
-{%- endfor %}
-{% endif %}
+{{- macros.column_list(gnql_stats.stats.categories, "category") }}
+{%- endif %}
 
 {%- if gnql_stats.stats.classifications %}
 Classifications:
-{%- for classification in gnql_stats.stats.classifications %}
-- {{ classification.classification }}: {{ classification.count }}
-{%- endfor %}
-{% endif %}
+{{- macros.column_list(gnql_stats.stats.classifications, "classification") }}
+{%- endif %}
 
 {%- if gnql_stats.stats.countries %}
 Countries:
-{%- for country in gnql_stats.stats.countries %}
-- {{ country.country }}: {{ country.count }}
-{%- endfor %}
-{% endif %}
+{{- macros.column_list(gnql_stats.stats.countries, "country") }}
+{%- endif %}
 
 {%- if gnql_stats.stats.operating_systems %}
 Operating systems:
-{%- for operating_system in gnql_stats.stats.operating_systems %}
-- {{ operating_system.operating_system }}: {{ operating_system.count }}
-{%- endfor %}
-{% endif %}
+{{- macros.column_list(gnql_stats.stats.operating_systems, "operating_system") }}
+{%- endif %}
 
 {%- if gnql_stats.stats.organizations %}
 Organizations:
-{%- for organization in gnql_stats.stats.organizations %}
-- {{ organization.organization }}: {{ organization.count }}
-{%- endfor %}
-{% endif %}
+{{- macros.column_list(gnql_stats.stats.organizations, "organization") }}
+{%- endif %}
 
 {%- if gnql_stats.stats.tags %}
 Tags:
-{%- for tag in gnql_stats.stats.tags %}
-- {{ tag.tag }}: {{ tag.count }}
-{%- endfor %}
-{% endif %}
+{{- macros.column_list(gnql_stats.stats.tags, "tag") }}
+{%- endif %}

--- a/src/greynoise/cli/templates/macros.txt.j2
+++ b/src/greynoise/cli/templates/macros.txt.j2
@@ -12,3 +12,11 @@
 Showing results 1 - 20. Run again with -v for full output.
 {% endif -%}
 {% endmacro %}
+
+{% macro column_list(elements, field_name) %}
+{%- set left_width = elements | map(attribute=field_name) | map('length') | max %}
+{%- set right_width = elements | map(attribute='count') | map('string') | map('length') | max %}
+{%- for element in elements %}
+- {{ "%-*s" | format(left_width, element[field_name]) }} {{ "%*s" | format(right_width, element.count) }}
+{%- endfor %}
+{% endmacro %}

--- a/src/greynoise/cli/templates/macros.txt.j2
+++ b/src/greynoise/cli/templates/macros.txt.j2
@@ -1,9 +1,12 @@
+# Render result header based on loop index and length
 {% macro result_header(loop) %}
 ┌───────────────────────────┐
 │ {{ "{:^25}".format("Result {} of {}".format(loop.index, loop.length)) }} │
 └───────────────────────────┘
 {% endmacro %}
 
+# Render all elements of a list when verbose=True
+# Otherwise, render first 20 elements and a message to remind user about verbose flag
 {% macro verbose_list(elements, verbose) %}
 {% for element in elements[:20 if not verbose else None] -%}
 {{ caller(element) }}
@@ -13,6 +16,8 @@ Showing results 1 - 20. Run again with -v for full output.
 {% endif -%}
 {% endmacro %}
 
+# Render tuples of element names and counts properly aligned
+# Width is based on the longest element in the list for each column
 {% macro column_list(elements, field_name) %}
 {%- set left_width = elements | map(attribute=field_name) | map('length') | max %}
 {%- set right_width = elements | map(attribute='count') | map('string') | map('length') | max %}

--- a/tests/cli/test_formatter.py
+++ b/tests/cli/test_formatter.py
@@ -212,64 +212,64 @@ class TestGNQLStatsFormatter(object):
                     "stats": {
                         "actors": None,
                         "asns": [
-                            {"asn": "<asn#1>", "count": 1},
-                            {"asn": "<asn#2>", "count": 1},
+                            {"asn": "<asn>", "count": 1},
+                            {"asn": "<long_asn>", "count": 1},
                         ],
                         "categories": [
-                            {"category": "<category#1>", "count": 1},
-                            {"category": "<category#2>", "count": 1},
+                            {"category": "<category>", "count": 1},
+                            {"category": "<long_category>", "count": 1},
                         ],
                         "classifications": [
-                            {"classification": "<classification#1>", "count": 1},
-                            {"classification": "<classification#2>", "count": 1},
+                            {"classification": "<classification>", "count": 1},
+                            {"classification": "<long_classification>", "count": 1},
                         ],
                         "countries": [
-                            {"country": "<country#1>", "count": 1},
-                            {"country": "<country#2>", "count": 1},
+                            {"country": "<country>", "count": 1},
+                            {"country": "<long_country>", "count": 1},
                         ],
                         "operating_systems": [
-                            {"operating_system": "<operating_system#1>", "count": 1},
-                            {"operating_system": "<operating_system#2>", "count": 1},
+                            {"operating_system": "<operating_system>", "count": 1},
+                            {"operating_system": "<long_operating_system>", "count": 1},
                         ],
                         "organizations": [
-                            {"organization": "<organization#1>", "count": 1},
-                            {"organization": "<organization#2>", "count": 1},
+                            {"organization": "<organization>", "count": 1},
+                            {"organization": "<long_organization>", "count": 1},
                         ],
                         "tags": [
-                            {"tag": "<tag#1>", "count": 1},
-                            {"tag": "<tag#2>", "count": 1},
+                            {"tag": "<tag>", "count": 1},
+                            {"tag": "<long_tag>", "count": 1},
                         ],
                     },
                 },
                 textwrap.dedent(
                     """\
                     ASNs:
-                    - <asn#1>: 1
-                    - <asn#2>: 1
+                    - <asn>      1
+                    - <long_asn> 1
 
                     Categories:
-                    - <category#1>: 1
-                    - <category#2>: 1
+                    - <category>      1
+                    - <long_category> 1
 
                     Classifications:
-                    - <classification#1>: 1
-                    - <classification#2>: 1
+                    - <classification>      1
+                    - <long_classification> 1
 
                     Countries:
-                    - <country#1>: 1
-                    - <country#2>: 1
+                    - <country>      1
+                    - <long_country> 1
 
                     Operating systems:
-                    - <operating_system#1>: 1
-                    - <operating_system#2>: 1
+                    - <operating_system>      1
+                    - <long_operating_system> 1
 
                     Organizations:
-                    - <organization#1>: 1
-                    - <organization#2>: 1
+                    - <organization>      1
+                    - <long_organization> 1
 
                     Tags:
-                    - <tag#1>: 1
-                    - <tag#2>: 1"""
+                    - <tag>      1
+                    - <long_tag> 1"""
                 ),
             ),
         ),


### PR DESCRIPTION
Update GNQL stats output to display values properly aligned. For example:
```
ASNs:
- <asn>      1
- <long_asn> 1

Categories:
- <category>      1
- <long_category> 1

Classifications:
- <classification>      1
- <long_classification> 1

Countries:
- <country>      1
- <long_country> 1

Operating systems:
- <operating_system>      1
- <long_operating_system> 1

Organizations:
- <organization>      1
- <long_organization> 1

Tags:
- <tag>      1
- <long_tag> 1
```