### PR TITLE
Handle 429 errors

### DIFF
--- a/src/greynoise/api.py
+++ b/src/greynoise/api.py
@@ -87,7 +87,7 @@ class GreyNoise(object):
         response = self.session.get(
             url, headers=headers, timeout=self.timeout, params=params, json=json
         )
-        if response.status_code not in range(200, 299):
+        if not 200 <= response.status_code < 300:
             raise RequestFailure(response.status_code, response.content)
 
         return response.json()

--- a/src/greynoise/api.py
+++ b/src/greynoise/api.py
@@ -4,7 +4,7 @@ import logging
 
 import requests
 
-from greynoise.exceptions import RequestFailure
+from greynoise.exceptions import RateLimitError, RequestFailure
 from greynoise.util import load_config, validate_ip
 
 LOGGER = logging.getLogger(__name__)
@@ -87,6 +87,9 @@ class GreyNoise(object):
         response = self.session.get(
             url, headers=headers, timeout=self.timeout, params=params, json=json
         )
+
+        if response.status_code == 429:
+            raise RateLimitError()
         if not 200 <= response.status_code < 300:
             raise RequestFailure(response.status_code, response.content)
 

--- a/src/greynoise/api.py
+++ b/src/greynoise/api.py
@@ -90,7 +90,11 @@ class GreyNoise(object):
         if not 200 <= response.status_code < 300:
             raise RequestFailure(response.status_code, response.content)
 
-        return response.json()
+        body = response.json()
+        if "error" in body:
+            raise RequestFailure(response.status_code, body)
+
+        return body
 
     def get_noise_status(self, ip_address):
         """Get activity associated with an IP address.

--- a/src/greynoise/cli/formatter.py
+++ b/src/greynoise/cli/formatter.py
@@ -61,10 +61,11 @@ def ip_multi_quick_check_formatter(ip_multi_quick_check, verbose):
 
 def gnql_query_formatter(gnql, verbose):
     """Convert GNQL query result into human-readable text."""
-    for ip_context in gnql["data"]:
-        if ip_context["seen"]:
-            metadata = ip_context["metadata"]
-            metadata["location"] = get_location(metadata)
+    if "data" in gnql:
+        for ip_context in gnql["data"]:
+            if ip_context["seen"]:
+                metadata = ip_context["metadata"]
+                metadata["location"] = get_location(metadata)
 
     template = JINJA2_ENV.get_template("gnql.txt.j2")
     return template.render(gnql=gnql, verbose=verbose)

--- a/src/greynoise/cli/templates/gnql.txt.j2
+++ b/src/greynoise/cli/templates/gnql.txt.j2
@@ -1,5 +1,9 @@
 {% import "macros.txt.j2" as macros %}
+{% if gnql.data %}
 {% for ip_context in gnql.data %}
 {{ macros.result_header(loop) }}
 {%- include "ip_context.txt.j2" %}
 {%- endfor %}
+{% else %}
+No results found for this query.
+{% endif %}

--- a/src/greynoise/exceptions.py
+++ b/src/greynoise/exceptions.py
@@ -3,3 +3,7 @@
 
 class RequestFailure(Exception):
     """Exception to capture a failed request."""
+
+
+class RateLimitError(RequestFailure):
+    """API rate limit passed."""


### PR DESCRIPTION
Handle 429 errors and a couple of error conditions that were not previously found:
- 200 OK response with "error" in the response.
- GNQL query for which no results were found.