### PR TITLE
Adding Dockerfile for Quay.io build for integrations

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Version control
+.git
+
+# Documentation
+docs
+
+# Unit test / coverage reports
+.pytest_cache
+.tox
+htmlcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.7-alpine as builder
+COPY . /app
+WORKDIR /app
+RUN python3 setup.py sdist bdist_wheel
+FROM python:3.7-alpine
+COPY --from=builder /app/dist/*.whl /app/
+WORKDIR /app
+RUN pip install /app/*.whl 
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM python:3.7-alpine as builder
 COPY . /app
 WORKDIR /app
-RUN python3 setup.py sdist bdist_wheel
+RUN pip install -r requirements/common.txt && python3 setup.py bdist_wheel
+
 FROM python:3.7-alpine
 COPY --from=builder /app/dist/*.whl /app/
 WORKDIR /app
-RUN pip install /app/*.whl && pip install six
+RUN pip install /app/*.whl

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,4 @@ RUN python3 setup.py sdist bdist_wheel
 FROM python:3.7-alpine
 COPY --from=builder /app/dist/*.whl /app/
 WORKDIR /app
-RUN pip install /app/*.whl 
-
-
+RUN pip install /app/*.whl && pip install six

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Python GreyNoise
 .. image:: https://img.shields.io/badge/License-MIT-yellow.svg
     :target: https://opensource.org/licenses/MIT
 
-.. image: https://quay.io/repository/greynoiseintel/pygreynoise/status
+.. image:: https://quay.io/repository/greynoiseintel/pygreynoise/status
     :target: https://quay.io/repository/greynoiseintel/pygreynoise
 
 This is an abstract python library built on top of the `GreyNoise`_ service. It is preferred that users use this library when implementing integrations or plan to use GreyNoise within their code. The library includes a small client to interact with the API.

--- a/README.rst
+++ b/README.rst
@@ -21,6 +21,9 @@ Python GreyNoise
 .. image:: https://img.shields.io/badge/License-MIT-yellow.svg
     :target: https://opensource.org/licenses/MIT
 
+.. image: https://quay.io/repository/greynoiseintel/pygreynoise/status
+    :target: https://quay.io/repository/greynoiseintel/pygreynoise
+
 This is an abstract python library built on top of the `GreyNoise`_ service. It is preferred that users use this library when implementing integrations or plan to use GreyNoise within their code. The library includes a small client to interact with the API.
 
 .. _GreyNoise: https://greynoise.io/


### PR DESCRIPTION
We might want to expand on this but I just need something in master to trigger the Quay.io builds so we can have a public image for pygreynoise.