### PR TITLE
Add docker changes

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+# Version control
+.git
+
+# Documentation
+docs
+
+# Unit test / coverage reports
+.pytest_cache
+.tox
+htmlcov

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.7-alpine as builder
 COPY . /app
 WORKDIR /app
-RUN python3 setup.py sdist bdist_wheel
+RUN pip install -r requirements/common.txt && python3 setup.py bdist_wheel
+
 FROM python:3.7-alpine
 COPY --from=builder /app/dist/*.whl /app/
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,4 +6,4 @@ RUN pip install -r requirements/common.txt && python3 setup.py bdist_wheel
 FROM python:3.7-alpine
 COPY --from=builder /app/dist/*.whl /app/
 WORKDIR /app
-RUN pip install /app/*.whl && pip install six
+RUN pip install /app/*.whl


### PR DESCRIPTION
Docker image build changes:
- Add .dockerignore file to reduce build context
- Install requirements with pip install

`pip install` is needed to reproduce build by using pinned library versions (same ones that have been tested).