### PR TITLE
Refactor API to be similar to the CLI

### DIFF
--- a/src/greynoise/api/__init__.py
+++ b/src/greynoise/api/__init__.py
@@ -1,0 +1,26 @@
+"""GreyNoise API client."""
+
+from greynoise.api.actors import Actors
+from greynoise.api.gnql import GNQL
+from greynoise.api.ip import IP
+from greynoise.util import load_config
+
+
+class GreyNoise(object):
+
+    """GreyNoise API client.
+
+    :param api_key: Key use to access the API.
+    :type api_key: str
+    :param timeout: API requests timeout in seconds.
+    :type timeout: int
+
+    """
+
+    def __init__(self, api_key=None, timeout=7):
+        if api_key is None:
+            api_key = load_config()["api_key"]
+
+        self.actors = Actors(api_key, timeout)
+        self.gnql = GNQL(api_key, timeout)
+        self.ip = IP(api_key, timeout)

--- a/src/greynoise/api/__init__.py
+++ b/src/greynoise/api/__init__.py
@@ -1,8 +1,10 @@
 """GreyNoise API client."""
 
 from greynoise.api.actors import Actors
-from greynoise.api.gnql import GNQL
 from greynoise.api.ip import IP
+from greynoise.api.query import Query
+from greynoise.api.quick import Quick
+from greynoise.api.stats import Stats
 from greynoise.util import load_config
 
 
@@ -22,5 +24,7 @@ class GreyNoise(object):
             api_key = load_config()["api_key"]
 
         self.actors = Actors(api_key, timeout)
-        self.gnql = GNQL(api_key, timeout)
         self.ip = IP(api_key, timeout)
+        self.query = Query(api_key, timeout)
+        self.quick = Quick(api_key, timeout)
+        self.stats = Stats(api_key, timeout)

--- a/src/greynoise/api/actors.py
+++ b/src/greynoise/api/actors.py
@@ -1,0 +1,21 @@
+import logging
+
+from greynoise.api.base import Base
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Actors(Base):
+
+    EP_RESEARCH_ACTORS = "research/actors"
+
+    def __call__(self):
+        """Get the names and IP addresses of actors scanning the Internet.
+
+        :returns: Most labeled actors scanning the intenet.
+        :rtype: list
+
+        """
+        LOGGER.debug("Getting actors...")
+        response = self._request(self.EP_RESEARCH_ACTORS)
+        return response

--- a/src/greynoise/api/base.py
+++ b/src/greynoise/api/base.py
@@ -1,0 +1,49 @@
+import requests
+
+from greynoise.exceptions import RateLimitError, RequestFailure
+
+
+class Base(object):
+    CLIENT_VERSION = "0.2.2"
+    API_VERSION = "v2"
+    BASE_URL = "https://enterprise.api.greynoise.io"
+
+    SESSION = requests.Session()
+
+    def __init__(self, api_key=None, timeout=7, use_cache=True):
+        self.api_key = api_key
+        self.timeout = timeout
+        self.use_cache = use_cache
+
+    def _request(self, endpoint, params=None, json=None):
+        """Handle the requesting of information from the API.
+
+        :param endpoint: Endpoint to send the request to.
+        :type endpoint: str
+        :param params: Request parameters.
+        :type param: dict
+        :param json: Request's JSON payload.
+        :type json: dict
+        :returns: Response's JSON payload
+        :rtype: dict
+        :raises RequestFailure: when HTTP status code is not 2xx
+
+        """
+        if params is None:
+            params = {}
+        headers = {
+            "User-Agent": "greyNoise/{}".format(self.CLIENT_VERSION),
+            "key": self.api_key,
+        }
+        url = "/".join([self.BASE_URL, self.API_VERSION, endpoint])
+        response = self.SESSION.get(
+            url, headers=headers, timeout=self.timeout, params=params, json=json
+        )
+
+        body = response.json()
+        if response.status_code == 429:
+            raise RateLimitError()
+        if not 200 <= response.status_code < 300:
+            raise RequestFailure(response.status_code, body)
+
+        return body

--- a/src/greynoise/api/base.py
+++ b/src/greynoise/api/base.py
@@ -2,6 +2,10 @@ import requests
 
 from greynoise.exceptions import RateLimitError, RequestFailure
 
+# Cache configuration
+MAX_SIZE = 1000
+TTL = 3600
+
 
 class Base(object):
     CLIENT_VERSION = "0.2.2"

--- a/src/greynoise/api/gnql.py
+++ b/src/greynoise/api/gnql.py
@@ -1,0 +1,23 @@
+import logging
+
+from greynoise.api.base import Base
+
+LOGGER = logging.getLogger(__name__)
+
+
+class GNQL(Base):
+
+    EP_GNQL = "experimental/gnql"
+    EP_GNQL_STATS = "experimental/gnql/stats"
+
+    def query(self, query):
+        """Run GNQL query."""
+        LOGGER.debug("Running GNQL query: %s...", query)
+        response = self._request(self.EP_GNQL, params={"query": query})
+        return response
+
+    def stats(self, query):
+        """Run GNQL stats query."""
+        LOGGER.debug("Running GNQL stats query: %s...", query)
+        response = self._request(self.EP_GNQL_STATS, params={"query": query})
+        return response

--- a/src/greynoise/api/ip.py
+++ b/src/greynoise/api/ip.py
@@ -1,9 +1,8 @@
 import logging
-from collections import OrderedDict
 
 import cachetools
 
-from greynoise.api.base import Base
+from greynoise.api.base import MAX_SIZE, TTL, Base
 from greynoise.util import validate_ip
 
 LOGGER = logging.getLogger(__name__)
@@ -11,115 +10,10 @@ LOGGER = logging.getLogger(__name__)
 
 class IP(Base):
 
-    EP_NOISE_QUICK = "noise/quick/{ip_address}"
-    EP_NOISE_MULTI = "noise/multi/quick"
     EP_NOISE_CONTEXT = "noise/context/{ip_address}"
-    UNKNOWN_CODE_MESSAGE = "Code message unknown: {}"
-    CODE_MESSAGES = {
-        "0x00": "IP has never been observed scanning the Internet",
-        "0x01": "IP has been observed by the GreyNoise sensor network",
-        "0x02": (
-            "IP has been observed scanning the GreyNoise sensor network, "
-            "but has not completed a full connection, meaning this can be spoofed"
-        ),
-        "0x03": (
-            "IP is adjacent to another host that has been directly observed "
-            "by the GreyNoise sensor network"
-        ),
-        "0x04": "RESERVED",
-        "0x05": "IP is commonly spoofed in Internet-scan activity",
-        "0x06": (
-            "IP has been observed as noise, but this host belongs to a cloud provider "
-            "where IPs can be cycled frequently"
-        ),
-        "0x07": "IP is invalid",
-        "0x08": (
-            "IP was classified as noise, but has not been observed "
-            "engaging in Internet-wide scans or attacks in over 60 days"
-        ),
-    }
-
-    MAX_SIZE = 1000
-    TTL = 3600
-    IP_QUICK_CHECK_CACHE = cachetools.TTLCache(maxsize=MAX_SIZE, ttl=TTL)
     IP_CONTEXT_CACHE = cachetools.TTLCache(maxsize=MAX_SIZE, ttl=TTL)
 
-    def quick_check(self, ip_address):
-        """Get activity associated with an IP address.
-
-        :param ip_address: IP address to use in the look-up.
-        :type recurse: str
-        :return: Activity metadata for the IP address.
-        :rtype: dict
-
-        """
-        LOGGER.debug("Getting noise status for %s...", ip_address)
-        validate_ip(ip_address)
-
-        endpoint = self.EP_NOISE_QUICK.format(ip_address=ip_address)
-        if self.use_cache:
-            cache = self.IP_QUICK_CHECK_CACHE
-            response = (
-                cache[ip_address]
-                if ip_address in cache
-                else cache.setdefault(ip_address, self._request(endpoint))
-            )
-        else:
-            response = self._request(endpoint)
-
-        code = response["code"]
-        response["code_message"] = self.CODE_MESSAGES.get(
-            code, self.UNKNOWN_CODE_MESSAGE.format(code)
-        )
-        return response
-
-    def multi_quick_check(self, ip_addresses):
-        """Get activity associated with multiple IP addresses.
-
-        :param ip_addresses: IP addresses to use in the look-up.
-        :type ip_addresses: list
-        :return: Bulk status information for IP addresses.
-        :rtype: dict
-
-        """
-        LOGGER.debug("Getting noise status for %s...", ip_addresses)
-        if not isinstance(ip_addresses, list):
-            raise ValueError("`ip_addresses` must be a list")
-
-        ip_addresses = [
-            ip_address
-            for ip_address in ip_addresses
-            if validate_ip(ip_address, strict=False)
-        ]
-
-        if self.use_cache:
-            cache = self.IP_QUICK_CHECK_CACHE
-            # Keep the same ordering as in the input
-            results = OrderedDict(
-                (ip_address, cache.get(ip_address)) for ip_address in ip_addresses
-            )
-            api_ip_addresses = [
-                ip_address for ip_address, result in results.items() if result is None
-            ]
-            if api_ip_addresses:
-                api_results = self._request(
-                    self.EP_NOISE_MULTI, json={"ips": api_ip_addresses}
-                )
-                for api_result in api_results:
-                    ip_address = api_result["ip"]
-                    results[ip_address] = cache.setdefault(ip_address, api_result)
-            results = list(results.values())
-        else:
-            results = self._request(self.EP_NOISE_MULTI, json={"ips": ip_addresses})
-
-        for result in results:
-            code = result["code"]
-            result["code_message"] = self.CODE_MESSAGES.get(
-                code, self.UNKNOWN_CODE_MESSAGE.format(code)
-            )
-        return results
-
-    def context(self, ip_address):
+    def __call__(self, ip_address):
         """Get context associated with an IP address.
 
         :param ip_address: IP address to use in the look-up.

--- a/src/greynoise/api/query.py
+++ b/src/greynoise/api/query.py
@@ -1,0 +1,16 @@
+import logging
+
+from greynoise.api.base import Base
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Query(Base):
+
+    EP_GNQL = "experimental/gnql"
+
+    def __call__(self, query):
+        """Run GNQL query."""
+        LOGGER.debug("Running GNQL query: %s...", query)
+        response = self._request(self.EP_GNQL, params={"query": query})
+        return response

--- a/src/greynoise/api/quick.py
+++ b/src/greynoise/api/quick.py
@@ -1,0 +1,98 @@
+import logging
+from collections import OrderedDict
+
+import cachetools
+
+from greynoise.api.base import MAX_SIZE, TTL, Base
+from greynoise.util import validate_ip
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Quick(Base):
+
+    EP_NOISE_QUICK = "noise/quick/{ip_address}"
+    EP_NOISE_MULTI = "noise/multi/quick"
+    UNKNOWN_CODE_MESSAGE = "Code message unknown: {}"
+    CODE_MESSAGES = {
+        "0x00": "IP has never been observed scanning the Internet",
+        "0x01": "IP has been observed by the GreyNoise sensor network",
+        "0x02": (
+            "IP has been observed scanning the GreyNoise sensor network, "
+            "but has not completed a full connection, meaning this can be spoofed"
+        ),
+        "0x03": (
+            "IP is adjacent to another host that has been directly observed "
+            "by the GreyNoise sensor network"
+        ),
+        "0x04": "RESERVED",
+        "0x05": "IP is commonly spoofed in Internet-scan activity",
+        "0x06": (
+            "IP has been observed as noise, but this host belongs to a cloud provider "
+            "where IPs can be cycled frequently"
+        ),
+        "0x07": "IP is invalid",
+        "0x08": (
+            "IP was classified as noise, but has not been observed "
+            "engaging in Internet-wide scans or attacks in over 60 days"
+        ),
+    }
+
+    IP_QUICK_CHECK_CACHE = cachetools.TTLCache(maxsize=MAX_SIZE, ttl=TTL)
+
+    def __call__(self, ip_addresses):
+        """Get activity associated with multiple IP addresses.
+
+        :param ip_addresses: IP addresses to use in the look-up.
+        :type ip_addresses: list
+        :return: Bulk status information for IP addresses.
+        :rtype: dict
+
+        """
+        LOGGER.debug("Getting noise status for %s...", ip_addresses)
+        if not isinstance(ip_addresses, list):
+            raise ValueError("`ip_addresses` must be a list")
+
+        ip_addresses = [
+            ip_address
+            for ip_address in ip_addresses
+            if validate_ip(ip_address, strict=False)
+        ]
+
+        if self.use_cache:
+            cache = self.IP_QUICK_CHECK_CACHE
+            # Keep the same ordering as in the input
+            results = OrderedDict(
+                (ip_address, cache.get(ip_address)) for ip_address in ip_addresses
+            )
+            api_ip_addresses = [
+                ip_address for ip_address, result in results.items() if result is None
+            ]
+            if api_ip_addresses:
+                if len(api_ip_addresses) == 1:
+                    endpoint = self.EP_NOISE_QUICK.format(
+                        ip_address=api_ip_addresses[0]
+                    )
+                    api_results = [self._request(endpoint)]
+                else:
+                    api_results = self._request(
+                        self.EP_NOISE_MULTI, json={"ips": api_ip_addresses}
+                    )
+
+                for api_result in api_results:
+                    ip_address = api_result["ip"]
+                    results[ip_address] = cache.setdefault(ip_address, api_result)
+            results = list(results.values())
+        else:
+            if len(ip_addresses) == 1:
+                endpoint = self.EP_NOISE_QUICK.format(ip_address=api_ip_addresses[0])
+                api_results = [self._request(endpoint)]
+            else:
+                results = self._request(self.EP_NOISE_MULTI, json={"ips": ip_addresses})
+
+        for result in results:
+            code = result["code"]
+            result["code_message"] = self.CODE_MESSAGES.get(
+                code, self.UNKNOWN_CODE_MESSAGE.format(code)
+            )
+        return results

--- a/src/greynoise/api/stats.py
+++ b/src/greynoise/api/stats.py
@@ -5,18 +5,11 @@ from greynoise.api.base import Base
 LOGGER = logging.getLogger(__name__)
 
 
-class GNQL(Base):
+class Stats(Base):
 
-    EP_GNQL = "experimental/gnql"
     EP_GNQL_STATS = "experimental/gnql/stats"
 
-    def query(self, query):
-        """Run GNQL query."""
-        LOGGER.debug("Running GNQL query: %s...", query)
-        response = self._request(self.EP_GNQL, params={"query": query})
-        return response
-
-    def stats(self, query):
+    def __call__(self, query):
         """Run GNQL stats query."""
         LOGGER.debug("Running GNQL stats query: %s...", query)
         response = self._request(self.EP_GNQL_STATS, params={"query": query})

--- a/src/greynoise/cli/subcommand.py
+++ b/src/greynoise/cli/subcommand.py
@@ -126,12 +126,12 @@ def ip(obj, ip_address):
     results = []
     if input_file is not None:
         results.extend(
-            api_client.get_context(ip_address=line.strip())
+            api_client.ip(ip_address=line.strip())
             for line in input_file
             if validate_ip(line, strict=False)
         )
     if ip_address:
-        results.append(api_client.get_context(ip_address=ip_address))
+        results.append(api_client.ip(ip_address=ip_address))
     return results
 
 
@@ -153,9 +153,9 @@ def query(obj, query):
     input_file = obj["input_file"]
     results = []
     if input_file is not None:
-        results.extend(api_client.run_query(query=line.strip()) for line in input_file)
+        results.extend(api_client.query(query=line.strip()) for line in input_file)
     if query:
-        results.append(api_client.run_query(query=query))
+        results.append(api_client.query(query=query))
     return results
 
 
@@ -180,10 +180,7 @@ def quick(obj, ip_address):
 
     results = []
     if ip_addresses:
-        if len(ip_addresses) == 1:
-            results.append(api_client.get_noise_status(ip_address=ip_addresses[0]))
-        else:
-            results.extend(api_client.get_noise_status_bulk(ip_addresses=ip_addresses))
+        results.extend(api_client.quick(ip_addresses=ip_addresses))
     return results
 
 
@@ -214,11 +211,9 @@ def stats(obj, query):
     input_file = obj["input_file"]
     results = []
     if input_file is not None:
-        results.extend(
-            api_client.run_stats_query(query=line.strip()) for line in input_file
-        )
+        results.extend(api_client.stats(query=line.strip()) for line in input_file)
     if query:
-        results.append(api_client.run_stats_query(query=query))
+        results.append(api_client.stats(query=query))
     return results
 
 


### PR DESCRIPTION
This is a PoC I wanted to show you and get your thoughts. The idea is to update the api to make it look like the CLI to be more consistent.

```
import greynoise

api = greynoise.GreyNoise()
api.ip.context('0.0.0.0')  # greynoise ip context 0.0.0.0
api.ip.quick_check('0.0.0.0')  # greynoise ip quick-check 0.0.0.0
api.gnql.query('0.0.0.0')  # greynoise gnql query 0.0.0.0
api.gnql.stats'0.0.0.0')  # greynoise gnql stats 0.0.0.0
```

What do you think?