### PR TITLE
Add six to requirements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,4 +7,3 @@ FROM python:3.7-alpine
 COPY --from=builder /app/dist/*.whl /app/
 WORKDIR /app
 RUN pip install /app/*.whl
-RUN pip install six

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -6,3 +6,4 @@ click-default-group==1.2.1
 dicttoxml==1.7.4
 jinja2==2.10.1
 requests==2.22.0
+six==1.12.0

--- a/setup.py
+++ b/setup.py
@@ -19,6 +19,7 @@ INSTALL_REQUIRES = [
     "dicttoxml",
     "jinja2",
     "requests",
+    "six",
 ]
 
 setup(


### PR DESCRIPTION
In the previous PR I removed the `pip install six` command thinking that `six` wasn't being used explicitly, but that was a mistake.

In this one, the six dependency is added to requirements and the Dockerfile is updated to avoid having to explicitly install it.