### PR TITLE
Calculate width for slice to be displayed

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
-[{*.py,*.rst}]
+[{*.py,*.rst,tox.ini}]
 indent_style = space
 indent_size = 4
 

--- a/src/greynoise/cli/templates/macros.txt.j2
+++ b/src/greynoise/cli/templates/macros.txt.j2
@@ -27,13 +27,14 @@ Showing results 1 - 20. Run again with -v for full output.
 # Width is based on the longest element in the list for each column
 # Also render follow same rules as "verbose_list" to render long lists
 {% macro column_verbose_list(elements, field_name, verbose) %}
+{%- set max_elements = 20 %}
 {%- set left_width = elements | map(attribute=field_name) | map('length') | max %}
 {%- set right_width = elements | map(attribute='count') | map('string') | map('length') | max %}
-{%- for element in elements[:20 if not verbose else None] %}
+{%- for element in elements[:max_elements if not verbose else None] %}
 - <key>{{ "%-*s" | format(left_width, element[field_name]) }}</key> <value>{{ "%*s" | format(right_width, element.count) }}</value>
 {%- endfor %}
-{% if elements | length > 20 and not verbose -%}
-Showing results 1 - 20. Run again with -v for full output.
+{% if elements | length > max_elements and not verbose -%}
+Showing results 1 - {{ max_elements }}. Run again with -v for full output.
 {% endif -%}
 {% endmacro %}
 

--- a/src/greynoise/cli/templates/macros.txt.j2
+++ b/src/greynoise/cli/templates/macros.txt.j2
@@ -28,9 +28,10 @@ Showing results 1 - 20. Run again with -v for full output.
 # Also render follow same rules as "verbose_list" to render long lists
 {% macro column_verbose_list(elements, field_name, verbose) %}
 {%- set max_elements = 20 %}
-{%- set left_width = elements | map(attribute=field_name) | map('length') | max %}
-{%- set right_width = elements | map(attribute='count') | map('string') | map('length') | max %}
-{%- for element in elements[:max_elements if not verbose else None] %}
+{%- set elements_slice = elements[:max_elements if not verbose else None] %}
+{%- set left_width = elements_slice | map(attribute=field_name) | map('length') | max %}
+{%- set right_width = elements_slice | map(attribute='count') | map('string') | map('length') | max %}
+{%- for element in elements_slice %}
 - <key>{{ "%-*s" | format(left_width, element[field_name]) }}</key> <value>{{ "%*s" | format(right_width, element.count) }}</value>
 {%- endfor %}
 {% if elements | length > max_elements and not verbose -%}

--- a/src/greynoise/cli/templates/macros.txt.j2
+++ b/src/greynoise/cli/templates/macros.txt.j2
@@ -15,11 +15,13 @@
 # Render all elements of a list when verbose=True
 # Otherwise, render first 20 elements and a message to remind user about verbose flag
 {% macro verbose_list(elements, verbose) %}
-{% for element in elements[:20 if not verbose else None] -%}
+{%- set max_elements = 20 %}
+{%- set elements_slice = elements[:max_elements if not verbose else None] %}
+{% for element in elements_slice -%}
 {{ caller(element) }}
 {%- endfor -%}
-{% if elements | length > 20 and not verbose -%}
-Showing results 1 - 20. Run again with -v for full output.
+{% if elements | length > max_elements and not verbose -%}
+Showing results 1 - {{ max_elements }}. Run again with -v for full output.
 {% endif -%}
 {% endmacro %}
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,12 @@
 [tox]
 envlist = py27, py35, py36, py37
 
-[testenv:py27]
-commands = pytest tests
+[testenv:py37]
+commands =
+    flake8 setup.py src tests docs
+    pytest tests
 
 [testenv]
 deps =
     -r{toxinidir}/requirements/test.txt
-commands =
-    flake8 setup.py src tests docs
-    pytest tests
+commands = pytest tests


### PR DESCRIPTION
In the stats command, calculate column width only for the slice of elements to be displayed.