### PR TITLE
Reduce duplication

### DIFF
--- a/src/greynoise/api.py
+++ b/src/greynoise/api.py
@@ -178,9 +178,10 @@ class GreyNoise(object):
                     )
                     api_results.append(self._request(endpoint))
                 else:
-                    for chunk in more_itertools.chunked(
+                    chunks = more_itertools.chunked(
                         api_ip_addresses, self.IP_QUICK_CHECK_CHUNK_SIZE
-                    ):
+                    )
+                    for chunk in chunks:
                         api_results.extend(
                             self._request(self.EP_NOISE_MULTI, json={"ips": chunk})
                         )
@@ -197,9 +198,10 @@ class GreyNoise(object):
                 endpoint = self.EP_NOISE_QUICK.format(ip_address=ip_addresses[0])
                 results.append(self._request(endpoint))
             else:
-                for chunk in more_itertools.chunked(
+                chunks = more_itertools.chunked(
                     ip_addresses, self.IP_QUICK_CHECK_CHUNK_SIZE
-                ):
+                )
+                for chunk in chunks:
                     results.extend(
                         self._request(self.EP_NOISE_MULTI, json={"ips": chunk})
                     )

--- a/src/greynoise/cli/decorator.py
+++ b/src/greynoise/cli/decorator.py
@@ -9,6 +9,7 @@ import click
 
 from greynoise.api import GreyNoise
 from greynoise.cli.formatter import FORMATTERS
+from greynoise.cli.parameter import ip_addresses_parameter
 from greynoise.exceptions import RequestFailure
 from greynoise.util import load_config
 
@@ -100,7 +101,7 @@ def pass_api_client(function):
     return wrapper
 
 
-def gnql(function):
+def gnql_command(function):
     """Decorator that groups decorators common to gnql query and stats subcommands."""
 
     @click.command()
@@ -116,6 +117,32 @@ def gnql(function):
         help="Output format",
     )
     @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
+    @pass_api_client
+    @click.pass_context
+    @echo_result
+    @handle_exceptions
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        return function(*args, **kwargs)
+
+    return wrapper
+
+
+def ip_lookup_command(function):
+    """Decorator that groups decorators common to ip and quick subcommand."""
+
+    @click.command()
+    @click.argument("ip_address", callback=ip_addresses_parameter, nargs=-1)
+    @click.option("-k", "--api-key", help="Key to include in API requests")
+    @click.option("-i", "--input", "input_file", type=click.File(), help="Input file")
+    @click.option(
+        "-f",
+        "--format",
+        "output_format",
+        type=click.Choice(["json", "txt", "xml"]),
+        default="txt",
+        help="Output format",
+    )
     @pass_api_client
     @click.pass_context
     @echo_result

--- a/src/greynoise/cli/decorator.py
+++ b/src/greynoise/cli/decorator.py
@@ -98,3 +98,30 @@ def pass_api_client(function):
         return function(api_client, *args, **kwargs)
 
     return wrapper
+
+
+def gnql(function):
+    """Decorator that groups decorators common to gnql query and stats subcommands."""
+
+    @click.command()
+    @click.argument("query", required=False)
+    @click.option("-k", "--api-key", help="Key to include in API requests")
+    @click.option("-i", "--input", "input_file", type=click.File(), help="Input file")
+    @click.option(
+        "-f",
+        "--format",
+        "output_format",
+        type=click.Choice(["json", "txt", "xml"]),
+        default="txt",
+        help="Output format",
+    )
+    @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
+    @pass_api_client
+    @click.pass_context
+    @echo_result
+    @handle_exceptions
+    @functools.wraps(function)
+    def wrapper(*args, **kwargs):
+        return function(*args, **kwargs)
+
+    return wrapper

--- a/src/greynoise/cli/helper.py
+++ b/src/greynoise/cli/helper.py
@@ -4,9 +4,49 @@ import sys
 
 import click
 
+from greynoise.util import validate_ip
+
+
+def get_ip_addresses(context, input_file, ip_address):
+    """Get IP addresses passed as argument or via input file.
+
+    :param context: Subcommand context
+    :type context: click.Context
+    :param input_file: Input file
+    :type input_file: click.File | None
+    :param ip_address: IP addresses passed via the ip address argument
+    :type query: tuple(str, ...)
+
+    """
+    if input_file is None and not sys.stdin.isatty():
+        input_file = sys.stdin
+
+    if input_file is None and not ip_address:
+        click.echo(context.get_help())
+        context.exit(-1)
+
+    ip_addresses = []
+    if input_file is not None:
+        lines = [line.strip() for line in input_file]
+        ip_addresses.extend([line for line in lines if validate_ip(line, strict=False)])
+    ip_addresses.extend(list(ip_address))
+
+    if not ip_addresses:
+        output = [
+            context.command.get_usage(context),
+            (
+                "Error: at least one valid IP address must be passed either as an "
+                "argument (IP_ADDRESS) or through the -i/--input_file option."
+            ),
+        ]
+        click.echo("\n\n".join(output))
+        context.exit(-1)
+
+    return ip_addresses
+
 
 def get_queries(context, input_file, query):
-    """Get queries passed as argument or thourgh input file.
+    """Get queries passed as argument or via input file.
 
     :param context: Subcommand context
     :type context: click.Context

--- a/src/greynoise/cli/helper.py
+++ b/src/greynoise/cli/helper.py
@@ -1,0 +1,43 @@
+"""Helper functions to reduce subcommand duplication."""
+
+import sys
+
+import click
+
+
+def get_queries(context, input_file, query):
+    """Get queries passed as argument or thourgh input file.
+
+    :param context: Subcommand context
+    :type context: click.Context
+    :param input_file: Input file
+    :type input_file: click.File | None
+    :param query: GNQL query
+    :type query: str | None
+
+    """
+    if input_file is None and not sys.stdin.isatty():
+        input_file = sys.stdin
+
+    if input_file is None and not query:
+        click.echo(context.get_help())
+        context.exit(-1)
+
+    queries = []
+    if input_file is not None:
+        queries.extend([line.strip() for line in input_file])
+    if query:
+        queries.append(query)
+
+    if not queries:
+        output = [
+            context.command.get_usage(context),
+            (
+                "Error: at least one query must be passed either as an argument "
+                "(QUERY) or through the -i/--input_file option."
+            ),
+        ]
+        click.echo("\n\n".join(output))
+        context.exit(-1)
+
+    return queries

--- a/src/greynoise/cli/parameter.py
+++ b/src/greynoise/cli/parameter.py
@@ -20,22 +20,3 @@ def ip_addresses_parameter(_context, _parameter, values):
             raise click.BadParameter(value)
 
     return values
-
-
-def ip_address_parameter(_context, _parameter, value):
-    """IPv4 address passed from the command line.
-
-    :param value: IPv4 address value
-    :type value: str
-    :raises click.BadParameter: when IP address value is invalid
-
-    """
-    if value is None:
-        return value
-
-    try:
-        validate_ip(value)
-    except ValueError:
-        raise click.BadParameter(value)
-
-    return value

--- a/src/greynoise/cli/subcommand.py
+++ b/src/greynoise/cli/subcommand.py
@@ -46,15 +46,15 @@ def feedback():
     raise SubcommandNotImplemented("feedback")
 
 
-@click.command()
-def filter():
+@click.command(name="filter")
+def filter_():
     """"Filter the noise from a log file, stdin, etc."""
     raise SubcommandNotImplemented("filter")
 
 
-@click.command()
+@click.command(name="help")
 @click.pass_context
-def help(context):
+def help_(context):
     """Show this message and exit."""
     click.echo(context.parent.get_help())
 

--- a/src/greynoise/cli/subcommand.py
+++ b/src/greynoise/cli/subcommand.py
@@ -4,7 +4,13 @@ import sys
 
 import click
 
-from greynoise.cli.decorator import echo_result, handle_exceptions, pass_api_client
+from greynoise.cli.decorator import (
+    echo_result,
+    gnql,
+    handle_exceptions,
+    pass_api_client,
+)
+from greynoise.cli.helper import get_queries
 from greynoise.cli.parameter import ip_address_parameter, ip_addresses_parameter
 from greynoise.util import CONFIG_FILE, save_config, validate_ip
 
@@ -119,49 +125,10 @@ def pcap():
     raise SubcommandNotImplemented("pcap")
 
 
-@click.command()
-@click.argument("query", required=False)
-@click.option("-k", "--api-key", help="Key to include in API requests")
-@click.option("-i", "--input", "input_file", type=click.File(), help="Input file")
-@click.option(
-    "-f",
-    "--format",
-    "output_format",
-    type=click.Choice(["json", "txt", "xml"]),
-    default="txt",
-    help="Output format",
-)
-@click.option("-v", "--verbose", is_flag=True, help="Verbose output")
-@pass_api_client
-@click.pass_context
-@echo_result
-@handle_exceptions
+@gnql
 def query(context, api_client, api_key, input_file, output_format, verbose, query):
     """Run a GNQL (GreyNoise Query Language) query."""
-    if input_file is None and not sys.stdin.isatty():
-        input_file = sys.stdin
-
-    if input_file is None and not query:
-        click.echo(context.get_help())
-        context.exit(-1)
-
-    queries = []
-    if input_file is not None:
-        queries.extend([line.strip() for line in input_file])
-    if query:
-        queries.append(query)
-
-    if not queries:
-        output = [
-            context.command.get_usage(context),
-            (
-                "Error: at least one query must be passed either as an argument "
-                "(QUERY) or through the -i/--input_file option."
-            ),
-        ]
-        click.echo("\n\n".join(output))
-        context.exit(-1)
-
+    queries = get_queries(context, input_file, query)
     results = [api_client.query(query=query) for query in queries]
     return results
 
@@ -229,49 +196,10 @@ def signature():
     raise SubcommandNotImplemented("signature")
 
 
-@click.command()
-@click.argument("query", required=False)
-@click.option("-k", "--api-key", help="Key to include in API requests")
-@click.option("-i", "--input", "input_file", type=click.File(), help="Input file")
-@click.option(
-    "-f",
-    "--format",
-    "output_format",
-    type=click.Choice(["json", "txt", "xml"]),
-    default="txt",
-    help="Output format",
-)
-@click.option("-v", "--verbose", is_flag=True, help="Verbose output")
-@pass_api_client
-@click.pass_context
-@echo_result
-@handle_exceptions
+@gnql
 def stats(context, api_client, api_key, input_file, output_format, verbose, query):
     """Get aggregate stats from a given GNQL query."""
-    if input_file is None and not sys.stdin.isatty():
-        input_file = sys.stdin
-
-    if input_file is None and not query:
-        click.echo(context.get_help())
-        context.exit(-1)
-
-    queries = []
-    if input_file is not None:
-        queries.extend([line.strip() for line in input_file])
-    if query:
-        queries.append(query)
-
-    if not queries:
-        output = [
-            context.command.get_usage(context),
-            (
-                "Error: at least one query must be passed either as an argument "
-                "(QUERY) or through the -i/--input_file option."
-            ),
-        ]
-        click.echo("\n\n".join(output))
-        context.exit(-1)
-
+    queries = get_queries(context, input_file, query)
     results = [api_client.stats(query=query) for query in queries]
     return results
 

--- a/src/greynoise/cli/subcommand.py
+++ b/src/greynoise/cli/subcommand.py
@@ -1,18 +1,10 @@
 """CLI subcommands."""
 
-import sys
-
 import click
 
-from greynoise.cli.decorator import (
-    echo_result,
-    gnql,
-    handle_exceptions,
-    pass_api_client,
-)
-from greynoise.cli.helper import get_queries
-from greynoise.cli.parameter import ip_addresses_parameter
-from greynoise.util import CONFIG_FILE, save_config, validate_ip
+from greynoise.cli.decorator import gnql_command, ip_lookup_command
+from greynoise.cli.helper import get_ip_addresses, get_queries
+from greynoise.util import CONFIG_FILE, save_config
 
 
 class SubcommandNotImplemented(click.ClickException):
@@ -71,49 +63,11 @@ def interesting():
     raise SubcommandNotImplemented("interesting")
 
 
-@click.command()
-@click.argument("ip_address", callback=ip_addresses_parameter, nargs=-1)
-@click.option("-k", "--api-key", help="Key to include in API requests")
-@click.option("-i", "--input", "input_file", type=click.File(), help="Input file")
-@click.option(
-    "-f",
-    "--format",
-    "output_format",
-    type=click.Choice(["json", "txt", "xml"]),
-    default="txt",
-    help="Output format",
-)
+@ip_lookup_command
 @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
-@pass_api_client
-@click.pass_context
-@echo_result
-@handle_exceptions
 def ip(context, api_client, api_key, input_file, output_format, verbose, ip_address):
     """Query GreyNoise for all information on a given IP."""
-    if input_file is None and not sys.stdin.isatty():
-        input_file = click.open_file("-")
-
-    if input_file is None and not ip_address:
-        click.echo(context.get_help())
-        context.exit(-1)
-
-    ip_addresses = []
-    if input_file is not None:
-        lines = [line.strip() for line in input_file]
-        ip_addresses.extend([line for line in lines if validate_ip(line, strict=False)])
-    ip_addresses.extend(list(ip_address))
-
-    if not ip_addresses:
-        output = [
-            context.command.get_usage(context),
-            (
-                "Error: at least one valid IP address must be passed either as an "
-                "argument (IP_ADDRESS) or through the -i/--input_file option."
-            ),
-        ]
-        click.echo("\n\n".join(output))
-        context.exit(-1)
-
+    ip_addresses = get_ip_addresses(context, input_file, ip_address)
     results = [api_client.ip(ip_address=ip_address) for ip_address in ip_addresses]
     return results
 
@@ -124,7 +78,7 @@ def pcap():
     raise SubcommandNotImplemented("pcap")
 
 
-@gnql
+@gnql_command
 def query(context, api_client, api_key, input_file, output_format, verbose, query):
     """Run a GNQL (GreyNoise Query Language) query."""
     queries = get_queries(context, input_file, query)
@@ -132,48 +86,10 @@ def query(context, api_client, api_key, input_file, output_format, verbose, quer
     return results
 
 
-@click.command()
-@click.argument("ip_address", callback=ip_addresses_parameter, nargs=-1)
-@click.option("-k", "--api-key", help="Key to include in API requests")
-@click.option("-i", "--input", "input_file", type=click.File(), help="Input file")
-@click.option(
-    "-f",
-    "--format",
-    "output_format",
-    type=click.Choice(["json", "txt", "xml"]),
-    default="txt",
-    help="Output format",
-)
-@pass_api_client
-@click.pass_context
-@echo_result
-@handle_exceptions
+@ip_lookup_command
 def quick(context, api_client, api_key, input_file, output_format, ip_address):
     """Quickly check whether or not one or many IPs are "noise"."""
-    if input_file is None and not sys.stdin.isatty():
-        input_file = sys.stdin
-
-    if input_file is None and not ip_address:
-        click.echo(context.get_help())
-        context.exit(-1)
-
-    ip_addresses = []
-    if input_file is not None:
-        lines = [line.strip() for line in input_file]
-        ip_addresses.extend([line for line in lines if validate_ip(line, strict=False)])
-    ip_addresses.extend(list(ip_address))
-
-    if not ip_addresses:
-        output = [
-            context.command.get_usage(context),
-            (
-                "Error: at least one valid IP address must be passed either as an "
-                "argument (IP_ADDRESS) or through the -i/--input_file option."
-            ),
-        ]
-        click.echo("\n\n".join(output))
-        context.exit(-1)
-
+    ip_addresses = get_ip_addresses(context, input_file, ip_address)
     results = []
     if ip_addresses:
         results.extend(api_client.quick(ip_addresses=ip_addresses))
@@ -195,7 +111,7 @@ def signature():
     raise SubcommandNotImplemented("signature")
 
 
-@gnql
+@gnql_command
 def stats(context, api_client, api_key, input_file, output_format, verbose, query):
     """Get aggregate stats from a given GNQL query."""
     queries = get_queries(context, input_file, query)

--- a/src/greynoise/cli/subcommand.py
+++ b/src/greynoise/cli/subcommand.py
@@ -11,7 +11,7 @@ from greynoise.cli.decorator import (
     pass_api_client,
 )
 from greynoise.cli.helper import get_queries
-from greynoise.cli.parameter import ip_address_parameter, ip_addresses_parameter
+from greynoise.cli.parameter import ip_addresses_parameter
 from greynoise.util import CONFIG_FILE, save_config, validate_ip
 
 
@@ -72,7 +72,7 @@ def interesting():
 
 
 @click.command()
-@click.argument("ip_address", callback=ip_address_parameter, required=False)
+@click.argument("ip_address", callback=ip_addresses_parameter, nargs=-1)
 @click.option("-k", "--api-key", help="Key to include in API requests")
 @click.option("-i", "--input", "input_file", type=click.File(), help="Input file")
 @click.option(
@@ -101,8 +101,7 @@ def ip(context, api_client, api_key, input_file, output_format, verbose, ip_addr
     if input_file is not None:
         lines = [line.strip() for line in input_file]
         ip_addresses.extend([line for line in lines if validate_ip(line, strict=False)])
-    if ip_address:
-        ip_addresses.append(ip_address)
+    ip_addresses.extend(list(ip_address))
 
     if not ip_addresses:
         output = [

--- a/tests/cli/test_subcommand.py
+++ b/tests/cli/test_subcommand.py
@@ -294,7 +294,7 @@ class TestQuery(object):
         """Usage is returned if no query or input file is passed."""
         runner = CliRunner()
 
-        with patch("greynoise.cli.subcommand.sys") as sys:
+        with patch("greynoise.cli.helper.sys") as sys:
             sys.stdin.isatty.return_value = True
             result = runner.invoke(
                 subcommand.query, parent=Context(main, info_name="greynoise")
@@ -616,7 +616,7 @@ class TestStats(object):
         """Usage is returned if no query or input file is passed."""
         runner = CliRunner()
 
-        with patch("greynoise.cli.subcommand.sys") as sys:
+        with patch("greynoise.cli.helper.sys") as sys:
             sys.stdin.isatty.return_value = True
             result = runner.invoke(
                 subcommand.stats, parent=Context(main, info_name="greynoise")

--- a/tests/cli/test_subcommand.py
+++ b/tests/cli/test_subcommand.py
@@ -170,7 +170,7 @@ class TestIP(object):
         """Usage is returned if no IP address or input file is passed."""
         runner = CliRunner()
 
-        with patch("greynoise.cli.subcommand.sys") as sys:
+        with patch("greynoise.cli.helper.sys") as sys:
             sys.stdin.isatty.return_value = True
             result = runner.invoke(
                 subcommand.ip, parent=Context(main, info_name="greynoise")
@@ -463,7 +463,7 @@ class TestQuick(object):
         """Usage is returned if no IP address or input file is passed."""
         runner = CliRunner()
 
-        with patch("greynoise.cli.subcommand.sys") as sys:
+        with patch("greynoise.cli.helper.sys") as sys:
             sys.stdin.isatty.return_value = True
             result = runner.invoke(
                 subcommand.quick, parent=Context(main, info_name="greynoise")

--- a/tests/cli/test_subcommand.py
+++ b/tests/cli/test_subcommand.py
@@ -86,7 +86,7 @@ class TestFilter(object):
         runner = CliRunner()
         expected_output = "Error: 'filter' subcommand is not implemented yet.\n"
 
-        result = runner.invoke(subcommand.filter)
+        result = runner.invoke(subcommand.filter_)
         assert result.exit_code == 1
         assert result.output == expected_output
 
@@ -100,7 +100,7 @@ class TestHelp(object):
         expected_output = "Usage: greynoise [OPTIONS] COMMAND [ARGS]..."
 
         result = runner.invoke(
-            subcommand.help, parent=Context(main, info_name="greynoise")
+            subcommand.help_, parent=Context(main, info_name="greynoise")
         )
         assert result.exit_code == 0
         assert expected_output in result.output

--- a/tests/cli/test_subcommand.py
+++ b/tests/cli/test_subcommand.py
@@ -202,7 +202,7 @@ class TestIP(object):
         """IP subcommand fails when ip_address is invalid."""
         runner = CliRunner()
 
-        expected = 'Error: Invalid value for "[IP_ADDRESS]": not-an-ip\n'
+        expected = 'Error: Invalid value for "[IP_ADDRESS]...": not-an-ip\n'
 
         result = runner.invoke(subcommand.ip, ["not-an-ip"])
         assert result.exit_code == 2


### PR DESCRIPTION
Reduce code duplication in the following subcommands:
- ip and quick
- query and stats 

Also add support for multiple IP addresses passed in directly as an argument to the `ip` subcommand, which makes it more similar to the `quick` subcommand.