### PR TITLE
Add repl subcommand

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,6 +5,7 @@ Click==7.0
 ansimarkup==1.4.0
 cachetools==3.1.1
 click-default-group==1.2.1
+click-repl==0.1.6
 dicttoxml==1.7.4
 jinja2==2.10.1
 requests==2.22.0

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ INSTALL_REQUIRES = [
     "ansimarkup",
     "cachetools",
     "click-default-group",
+    "click-repl",
     "dicttoxml",
     "jinja2",
     "more-itertools",

--- a/setup.py
+++ b/setup.py
@@ -12,10 +12,10 @@ def read(fname):
 
 
 INSTALL_REQUIRES = [
+    "Click>=7.0",
     "ansimarkup",
     "cachetools",
-    "click-default-group",  # must be before click, otherwise "setup.py install" fails
-    "click",
+    "click-default-group",
     "dicttoxml",
     "jinja2",
     "more-itertools",

--- a/src/greynoise/cli/__init__.py
+++ b/src/greynoise/cli/__init__.py
@@ -3,8 +3,9 @@
 import logging
 
 import click
-
 from click_default_group import DefaultGroup
+from click_repl import register_repl
+
 from greynoise.cli import subcommand
 
 logging.basicConfig(level=logging.WARNING, format="%(levelname)s: %(message)s")
@@ -28,3 +29,5 @@ SUBCOMMAND_FUNCTIONS = [
 
 for subcommand_function in SUBCOMMAND_FUNCTIONS:
     main.add_command(subcommand_function)
+
+register_repl(main)


### PR DESCRIPTION
Use `click-repl` to get a new `repl` subcommand that can be used to run multiple command without using the `greynoise` prefix and get autocompletion functionality.