### PR TITLE
Handle timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Version `0.3.0`_
 
   * add help subcommand.
   * global options moved to those subcommands where they apply.
+  * make request timeout configurable.
 
 
 Version `0.2.2`_

--- a/src/greynoise/__init__.py
+++ b/src/greynoise/__init__.py
@@ -1,7 +1,5 @@
 """GreyNoise API client and tools."""
 
-import logging
-
 from greynoise.api import GreyNoise  # noqa
 
 __author__ = "GreyNoise Intelligence"
@@ -11,6 +9,3 @@ __license__ = "MIT"
 __maintainer__ = "GreyNoise Intelligence"
 __email__ = "hello@greynoise.io"
 __status__ = "BETA"
-
-
-logging.getLogger(__name__).addHandler(logging.NullHandler())

--- a/src/greynoise/api.py
+++ b/src/greynoise/api.py
@@ -65,9 +65,13 @@ class GreyNoise(object):
 
     IP_QUICK_CHECK_CHUNK_SIZE = 1000
 
-    def __init__(self, api_key=None, timeout=60, use_cache=True):
-        if api_key is None:
-            api_key = load_config()["api_key"]
+    def __init__(self, api_key=None, timeout=None, use_cache=True):
+        if api_key is None or timeout is None:
+            config = load_config()
+            if api_key is None:
+                api_key = config["api_key"]
+            if timeout is None:
+                timeout = config["timeout"]
         self.api_key = api_key
         self.timeout = timeout
         self.use_cache = use_cache

--- a/src/greynoise/cli/decorator.py
+++ b/src/greynoise/cli/decorator.py
@@ -83,9 +83,9 @@ def pass_api_client(function):
     def wrapper(*args, **kwargs):
         context = click.get_current_context()
         api_key = context.params["api_key"]
+        config = load_config()
 
         if api_key is None:
-            config = load_config()
             if not config["api_key"]:
                 prog_name = context.parent.info_name
                 click.echo(
@@ -101,7 +101,7 @@ def pass_api_client(function):
                 context.exit(-1)
             api_key = config["api_key"]
 
-        api_client = GreyNoise(api_key)
+        api_client = GreyNoise(api_key=api_key, timeout=config["timeout"])
         return function(api_client, *args, **kwargs)
 
     return wrapper

--- a/src/greynoise/cli/decorator.py
+++ b/src/greynoise/cli/decorator.py
@@ -6,6 +6,7 @@ Decorators used to add common functionality to subcommands.
 import functools
 
 import click
+from requests.exceptions import RequestException
 
 from greynoise.api import GreyNoise
 from greynoise.cli.formatter import FORMATTERS
@@ -60,6 +61,9 @@ def handle_exceptions(function):
         except RequestFailure as exception:
             body = exception.args[1]
             click.echo("API error: {}".format(body["error"]))
+            click.get_current_context().exit(-1)
+        except RequestException as exception:
+            click.echo("API error: {}".format(exception))
             click.get_current_context().exit(-1)
 
     return wrapper

--- a/src/greynoise/cli/subcommand.py
+++ b/src/greynoise/cli/subcommand.py
@@ -4,7 +4,7 @@ import click
 
 from greynoise.cli.decorator import gnql_command, ip_lookup_command
 from greynoise.cli.helper import get_ip_addresses, get_queries
-from greynoise.util import CONFIG_FILE, save_config
+from greynoise.util import CONFIG_FILE, DEFAULT_CONFIG, save_config
 
 
 class SubcommandNotImplemented(click.ClickException):
@@ -111,9 +111,14 @@ def quick(
 
 @click.command()
 @click.option("-k", "--api-key", required=True, help="Key to include in API requests")
-def setup(api_key):
+@click.option("-t", "--timeout", help="API client request timeout")
+def setup(api_key, timeout):
     """Configure API key."""
     config = {"api_key": api_key}
+    if timeout is None:
+        config["timeout"] = DEFAULT_CONFIG["timeout"]
+    else:
+        config["timeout"] = timeout
     save_config(config)
     click.echo("Configuration saved to {!r}".format(CONFIG_FILE))
 

--- a/src/greynoise/cli/subcommand.py
+++ b/src/greynoise/cli/subcommand.py
@@ -111,7 +111,7 @@ def quick(
 
 @click.command()
 @click.option("-k", "--api-key", required=True, help="Key to include in API requests")
-@click.option("-t", "--timeout", help="API client request timeout")
+@click.option("-t", "--timeout", type=click.INT, help="API client request timeout")
 def setup(api_key, timeout):
     """Configure API key."""
     config = {"api_key": api_key}

--- a/src/greynoise/util.py
+++ b/src/greynoise/util.py
@@ -20,7 +20,9 @@ def load_config():
     :rtype: dict
 
     """
-    config_parser = ConfigParser(DEFAULT_CONFIG)
+    config_parser = ConfigParser(
+        {key: str(value) for key, value in DEFAULT_CONFIG.items()}
+    )
     config_parser.add_section("greynoise")
 
     if os.path.isfile(CONFIG_FILE):

--- a/src/greynoise/util.py
+++ b/src/greynoise/util.py
@@ -9,6 +9,8 @@ from six.moves.configparser import ConfigParser
 CONFIG_FILE = os.path.expanduser(os.path.join("~", ".config", "greynoise", "config"))
 LOGGER = logging.getLogger(__name__)
 
+DEFAULT_CONFIG = {"api_key": "", "timeout": 60}
+
 
 def load_config():
     """Load configuration.
@@ -18,8 +20,7 @@ def load_config():
     :rtype: dict
 
     """
-    defaults = {"api_key": ""}
-    config_parser = ConfigParser(defaults)
+    config_parser = ConfigParser(DEFAULT_CONFIG)
     config_parser.add_section("greynoise")
 
     if os.path.isfile(CONFIG_FILE):
@@ -32,11 +33,28 @@ def load_config():
     if "GREYNOISE_API_KEY" in os.environ:
         api_key = os.environ["GREYNOISE_API_KEY"]
         LOGGER.debug("API key found in environment variable: %s", api_key)
-
         # Environment variable takes precedence over configuration file content
         config_parser.set("greynoise", "api_key", api_key)
 
-    return {"api_key": config_parser.get("greynoise", "api_key")}
+    if "GREYNOISE_TIMEOUT" in os.environ:
+        timeout = os.environ["GREYNOISE_TIMEOUT"]
+        try:
+            int(timeout)
+        except ValueError:
+            LOGGER.error(
+                "GREYNOISE_TIMEOUT environment variable "
+                "cannot be converted to an integer: %r",
+                timeout,
+            )
+        else:
+            LOGGER.debug("Timeout found in environment variable: %s", timeout)
+            # Environment variable takes precedence over configuration file content
+            config_parser.set("greynoise", "timeout", timeout)
+
+    return {
+        "api_key": config_parser.get("greynoise", "api_key"),
+        "timeout": config_parser.getint("greynoise", "timeout"),
+    }
 
 
 def save_config(config):

--- a/src/greynoise/util.py
+++ b/src/greynoise/util.py
@@ -67,6 +67,7 @@ def save_config(config):
     config_parser = ConfigParser()
     config_parser.add_section("greynoise")
     config_parser.set("greynoise", "api_key", config["api_key"])
+    config_parser.set("greynoise", "timeout", str(config["timeout"]))
 
     config_dir = os.path.dirname(CONFIG_FILE)
     if not os.path.isdir(config_dir):

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,19 +28,21 @@ class TestInit(object):
 
     def test_with_api_key(self):
         """API parameter is passed."""
-        expected = "<api_key>"
+        config = {"api_key": "<api_key>", "timeout": "<timeout>"}
         with patch("greynoise.api.load_config") as load_config:
-            client = GreyNoise(api_key=expected)
-            assert client.api_key == expected
+            client = GreyNoise(**config)
+            assert client.api_key == config["api_key"]
+            assert client.timeout == config["timeout"]
             load_config.assert_not_called()
 
     def test_without_api_key(self):
         """API parameter is not passed."""
-        expected = "<api_key>"
+        config = {"api_key": "<api_key>", "timeout": "<timeout>"}
         with patch("greynoise.api.load_config") as load_config:
-            load_config.return_value = {"api_key": expected}
+            load_config.return_value = config
             client = GreyNoise()
-            assert client.api_key == expected
+            assert client.api_key == config["api_key"]
+            assert client.timeout == config["timeout"]
             load_config.assert_called()
 
 


### PR DESCRIPTION
- In CLI, display error message when `requests` raises an exception
- Add `timeout` value to configuration file
- Add `-t/--timeout` option to `setup` command
- Use `GREYNOISE_TIMEOUT` environment variable value if available.

Fixes #100 