### PR TITLE
Truncate key in column output

### DIFF
--- a/src/greynoise/cli/decorator.py
+++ b/src/greynoise/cli/decorator.py
@@ -125,7 +125,7 @@ def gnql_command(function):
         default="txt",
         help="Output format",
     )
-    @click.option("-v", "--verbose", is_flag=True, help="Verbose output")
+    @click.option("-v", "--verbose", count=True, help="Verbose output")
     @pass_api_client
     @click.pass_context
     @echo_result

--- a/src/greynoise/cli/formatter.py
+++ b/src/greynoise/cli/formatter.py
@@ -8,10 +8,10 @@ import json
 from xml.dom.minidom import parseString
 
 import ansimarkup
+import click
 import colorama
-from jinja2 import Environment, PackageLoader
-
 from dicttoxml import dicttoxml
+from jinja2 import Environment, PackageLoader
 
 JINJA2_ENV = Environment(loader=PackageLoader("greynoise.cli"))
 
@@ -111,7 +111,8 @@ def gnql_query_formatter(results, verbose):
 def gnql_stats_formatter(results, verbose):
     """Convert GNQL stats result into human-readable text."""
     template = JINJA2_ENV.get_template("gnql_stats.txt.j2")
-    return template.render(results=results, verbose=verbose)
+    max_width, _ = click.get_terminal_size()
+    return template.render(results=results, verbose=verbose, max_width=max_width)
 
 
 FORMATTERS = {

--- a/src/greynoise/cli/subcommand.py
+++ b/src/greynoise/cli/subcommand.py
@@ -67,7 +67,7 @@ def interesting():
 
 
 @ip_lookup_command
-@click.option("-v", "--verbose", is_flag=True, help="Verbose output")
+@click.option("-v", "--verbose", count=True, help="Verbose output")
 def ip(
     context,
     api_client,

--- a/src/greynoise/cli/templates/gnql_stats.txt.j2
+++ b/src/greynoise/cli/templates/gnql_stats.txt.j2
@@ -1,46 +1,46 @@
-{% import "macros.txt.j2" as macros %}
+{% import "macros.txt.j2" as macros with context %}
 {% for result in results -%}
 {% call macros.header(loop) %}Query{% endcall -%}
 Query: {{ result.query }}
 {% if result.count > 0 %}
 {%- if result.stats.actors %}
 <header>Actors<header>:
-{{- macros.column_verbose_list(result.stats.actors, "actor", verbose) }}
+{{- macros.column_verbose_list(result.stats.actors, "actor") }}
 {%- endif %}
 
 {%- if result.stats.asns %}
 <header>ASNs</header>:
-{{- macros.column_verbose_list(result.stats.asns, "asn", verbose) }}
+{{- macros.column_verbose_list(result.stats.asns, "asn") }}
 {%- endif %}
 
 {%- if result.stats.categories %}
 <header>Categories</header>:
-{{- macros.column_verbose_list(result.stats.categories, "category", verbose) }}
+{{- macros.column_verbose_list(result.stats.categories, "category") }}
 {%- endif %}
 
 {%- if result.stats.classifications %}
 <header>Classifications</header>:
-{{- macros.column_verbose_list(result.stats.classifications, "classification", verbose) }}
+{{- macros.column_verbose_list(result.stats.classifications, "classification") }}
 {%- endif %}
 
 {%- if result.stats.countries %}
 <header>Countries</header>:
-{{- macros.column_verbose_list(result.stats.countries, "country", verbose) }}
+{{- macros.column_verbose_list(result.stats.countries, "country") }}
 {%- endif %}
 
 {%- if result.stats.operating_systems %}
 <header>Operating systems</header>:
-{{- macros.column_verbose_list(result.stats.operating_systems, "operating_system", verbose) }}
+{{- macros.column_verbose_list(result.stats.operating_systems, "operating_system") }}
 {%- endif %}
 
 {%- if result.stats.organizations %}
 <header>Organizations</header>:
-{{- macros.column_verbose_list(result.stats.organizations, "organization", verbose) }}
+{{- macros.column_verbose_list(result.stats.organizations, "organization") }}
 {%- endif %}
 
 {%- if result.stats.tags %}
 <header>Tags</header>:
-{{- macros.column_verbose_list(result.stats.tags, "tag", verbose) }}
+{{- macros.column_verbose_list(result.stats.tags, "tag") }}
 {%- endif %}
 {%- else %}
 No results found for this query.

--- a/src/greynoise/cli/templates/ip_context_result.txt.j2
+++ b/src/greynoise/cli/templates/ip_context_result.txt.j2
@@ -1,4 +1,4 @@
-{% import "macros.txt.j2" as macros %}
+{% import "macros.txt.j2" as macros with context %}
 {%- if ip_context.seen %}
           <header>OVERVIEW</header>
 ----------------------------
@@ -8,7 +8,7 @@
 <key>IP</key>: <value>{{ ip_context.ip }}</value>
 <key>Last seen</key>: <value>{{ ip_context.last_seen }}</value>
 <key>Tags</key>:
-{%- call(tag) macros.verbose_list(ip_context.tags, verbose) -%}
+{%- call(tag) macros.verbose_list(ip_context.tags) -%}
 - <value>{{ tag }}</value>
 {% endcall %}
           <header>METADATA</header>
@@ -25,21 +25,21 @@
 ----------------------------
 {%- if ip_context.raw_data.scan %}
 [Scan]
-{%- call(scan) macros.verbose_list(ip_context.raw_data.scan, verbose) -%}
+{%- call(scan) macros.verbose_list(ip_context.raw_data.scan) -%}
 - <key>Port/Proto</key>: <value>{{ scan.port }}/{{ scan.protocol }}</value>
 {% endcall -%}
 {% endif %}
 
 {%- if ip_context.raw_data.web.paths %}
 [Paths]
-{%- call(path) macros.verbose_list(ip_context.raw_data.web.paths, verbose) -%}
+{%- call(path) macros.verbose_list(ip_context.raw_data.web.paths) -%}
 - <value>{{ path }}</value>
 {% endcall -%}
 {% endif %}
 
 {%- if ip_context.raw_data.ja3 %}
 [JA3]
-{%- call(ja3) macros.verbose_list(ip_context.raw_data.ja3, verbose) -%}
+{%- call(ja3) macros.verbose_list(ip_context.raw_data.ja3) -%}
 - <key>Port</key>: <value>{{ ja3.port }}</value>, <key>Fingerprint</key>: <value>{{ ja3.fingerprint }}</value>
 {% endcall -%}
 {% endif %}

--- a/src/greynoise/cli/templates/macros.txt.j2
+++ b/src/greynoise/cli/templates/macros.txt.j2
@@ -31,10 +31,11 @@ Showing results 1 - {{ max_elements }}. Run again with -v for full output.
 {% macro column_verbose_list(elements, field_name) %}
 {%- set max_elements = 20 %}
 {%- set elements_slice = elements[:max_elements if verbose < 1 else None] %}
-{%- set left_width = elements_slice | map(attribute=field_name) | map('length') | max %}
 {%- set right_width = elements_slice | map(attribute='count') | map('string') | map('length') | max %}
+{%- set left_width_verbose = elements_slice | map(attribute=field_name) | map('length') | max %}
+{%- set left_width = left_width_verbose if verbose > 1 else [left_width_verbose, max_width - 3 - right_width] | min %}
 {%- for element in elements_slice %}
-- <key>{{ "%-*s" | format(left_width, element[field_name]) }}</key> <value>{{ "%*s" | format(right_width, element.count) }}</value>
+- <key>{{ "%-*s" | format(left_width, element[field_name] | truncate(left_width, True, "...", 0)) }}</key> <value>{{ "%*s" | format(right_width, element.count) }}</value>
 {%- endfor %}
 {% if elements | length > max_elements and verbose < 1 -%}
 Showing results 1 - {{ max_elements }}. Run again with -v for full output.

--- a/src/greynoise/cli/templates/macros.txt.j2
+++ b/src/greynoise/cli/templates/macros.txt.j2
@@ -14,7 +14,7 @@
 
 # Render all elements of a list when verbose=True
 # Otherwise, render first 20 elements and a message to remind user about verbose flag
-{% macro verbose_list(elements, verbose) %}
+{% macro verbose_list(elements) %}
 {%- set max_elements = 20 %}
 {%- set elements_slice = elements[:max_elements if verbose < 1 else None] %}
 {% for element in elements_slice -%}
@@ -28,7 +28,7 @@ Showing results 1 - {{ max_elements }}. Run again with -v for full output.
 # Render tuples of element names and counts properly aligned
 # Width is based on the longest element in the list for each column
 # Also render follow same rules as "verbose_list" to render long lists
-{% macro column_verbose_list(elements, field_name, verbose) %}
+{% macro column_verbose_list(elements, field_name) %}
 {%- set max_elements = 20 %}
 {%- set elements_slice = elements[:max_elements if verbose < 1 else None] %}
 {%- set left_width = elements_slice | map(attribute=field_name) | map('length') | max %}

--- a/src/greynoise/cli/templates/macros.txt.j2
+++ b/src/greynoise/cli/templates/macros.txt.j2
@@ -16,11 +16,11 @@
 # Otherwise, render first 20 elements and a message to remind user about verbose flag
 {% macro verbose_list(elements, verbose) %}
 {%- set max_elements = 20 %}
-{%- set elements_slice = elements[:max_elements if not verbose else None] %}
+{%- set elements_slice = elements[:max_elements if verbose < 1 else None] %}
 {% for element in elements_slice -%}
 {{ caller(element) }}
 {%- endfor -%}
-{% if elements | length > max_elements and not verbose -%}
+{% if elements | length > max_elements and verbose < 1  -%}
 Showing results 1 - {{ max_elements }}. Run again with -v for full output.
 {% endif -%}
 {% endmacro %}
@@ -30,13 +30,13 @@ Showing results 1 - {{ max_elements }}. Run again with -v for full output.
 # Also render follow same rules as "verbose_list" to render long lists
 {% macro column_verbose_list(elements, field_name, verbose) %}
 {%- set max_elements = 20 %}
-{%- set elements_slice = elements[:max_elements if not verbose else None] %}
+{%- set elements_slice = elements[:max_elements if verbose < 1 else None] %}
 {%- set left_width = elements_slice | map(attribute=field_name) | map('length') | max %}
 {%- set right_width = elements_slice | map(attribute='count') | map('string') | map('length') | max %}
 {%- for element in elements_slice %}
 - <key>{{ "%-*s" | format(left_width, element[field_name]) }}</key> <value>{{ "%*s" | format(right_width, element.count) }}</value>
 {%- endfor %}
-{% if elements | length > max_elements and not verbose -%}
+{% if elements | length > max_elements and verbose < 1 -%}
 Showing results 1 - {{ max_elements }}. Run again with -v for full output.
 {% endif -%}
 {% endmacro %}


### PR DESCRIPTION
- Truncate key column in stats subcommand output to fit into the terminal width.
- Do not truncate if "-vv" is passed (using just -v will display all elements in the list as usual)