### PR TITLE
Update twine to 2.0.0

### DIFF
--- a/requirements/test-py3.txt
+++ b/requirements/test-py3.txt
@@ -1,3 +1,4 @@
 black==19.10b0;python_version>='3.6'
 pylint==2.4.3;python_version>='3'
 pytest==5.2.2;python_version>='3'
+twine==2.0.0;python_version>='3.6'

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,5 +6,4 @@ flake8==3.7.9
 isort==4.3.21
 mock==3.0.5
 pytest-cov==2.7.1
-twine==1.15.0
 yamllint==1.18.0


### PR DESCRIPTION
Only installed when python>=3.6 because that's what twine requires now.
This is fine because twine is only called in the pypi circleci job that
uses python 3.7.