### PR TITLE
Add size and scroll parameters to GreyNoise.query

### DIFF
--- a/src/greynoise/api.py
+++ b/src/greynoise/api.py
@@ -157,10 +157,17 @@ class GreyNoise(object):
         response = self._request(endpoint)
         return response
 
-    def query(self, query):
+    def query(self, query, size=None, scroll=None):
         """Run GNQL query."""
-        LOGGER.debug("Running GNQL query: %s...", query, query=query)
-        response = self._request(self.EP_GNQL, params={"query": query})
+        LOGGER.debug(
+            "Running GNQL query: %s...", query, query=query, size=size, scroll=scroll
+        )
+        params = {"query": query}
+        if size is not None:
+            params["size"] = size
+        if scroll is not None:
+            params["scroll"] = scroll
+        response = self._request(self.EP_GNQL, params=params)
         return response
 
     def quick(self, ip_addresses):

--- a/src/greynoise/api.py
+++ b/src/greynoise/api.py
@@ -9,8 +9,10 @@ import structlog
 
 from greynoise.__version__ import __version__
 from greynoise.exceptions import RateLimitError, RequestFailure
-from greynoise.util import load_config, validate_ip
+from greynoise.util import configure_logging, load_config, validate_ip
 
+if not structlog.is_configured():
+    configure_logging()
 LOGGER = structlog.get_logger()
 
 

--- a/src/greynoise/cli/__init__.py
+++ b/src/greynoise/cli/__init__.py
@@ -1,35 +1,12 @@
 """GreyNoise command line Interface."""
 
-import logging
-import sys
-
 import click
 import structlog
 from click_default_group import DefaultGroup
 from click_repl import register_repl
 
 from greynoise.cli import subcommand
-
-
-def configure_logging():
-    """Configure logging."""
-    logging.basicConfig(stream=sys.stderr, format="%(message)s", level=logging.CRITICAL)
-    logging.getLogger("greynoise").setLevel(logging.WARNING)
-    structlog.configure(
-        processors=[
-            structlog.stdlib.add_logger_name,
-            structlog.stdlib.add_log_level,
-            structlog.stdlib.PositionalArgumentsFormatter(),
-            structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M.%S"),
-            structlog.processors.StackInfoRenderer(),
-            structlog.processors.format_exc_info,
-            structlog.dev.ConsoleRenderer(),
-        ],
-        context_class=dict,
-        logger_factory=structlog.stdlib.LoggerFactory(),
-        wrapper_class=structlog.stdlib.BoundLogger,
-        cache_logger_on_first_use=True,
-    )
+from greynoise.util import configure_logging
 
 
 @click.group(
@@ -40,7 +17,8 @@ def configure_logging():
 )
 def main():
     """GreyNoise CLI."""
-    configure_logging()
+    if not structlog.is_configured():
+        configure_logging()
 
 
 SUBCOMMAND_FUNCTIONS = [

--- a/src/greynoise/cli/formatter.py
+++ b/src/greynoise/cli/formatter.py
@@ -11,9 +11,12 @@ import ansimarkup
 import click
 import colorama
 from dicttoxml import dicttoxml
-from jinja2 import Environment, PackageLoader
+from jinja2 import Environment, PackageLoader, select_autoescape
 
-JINJA2_ENV = Environment(loader=PackageLoader("greynoise.cli"))
+JINJA2_ENV = Environment(
+    loader=PackageLoader("greynoise.cli"),
+    autoescape=select_autoescape(disabled_extensions=["txt.j2"]),
+)
 
 colorama.init()
 ANSI_MARKUP = ansimarkup.AnsiMarkup(

--- a/src/greynoise/cli/templates/ip_context_result.txt.j2
+++ b/src/greynoise/cli/templates/ip_context_result.txt.j2
@@ -7,10 +7,12 @@
 <key>First seen</key>: <value>{{ ip_context.first_seen }}</value>
 <key>IP</key>: <value>{{ ip_context.ip }}</value>
 <key>Last seen</key>: <value>{{ ip_context.last_seen }}</value>
+{% if ip_context.tags -%}
 <key>Tags</key>:
 {%- call(tag) macros.verbose_list(ip_context.tags) -%}
 - <value>{{ tag }}</value>
-{% endcall %}
+{% endcall -%}
+{% endif %}
           <header>METADATA</header>
 ----------------------------
 <key>ASN</key>: <value>{{ ip_context.metadata.asn }}</value>

--- a/src/greynoise/util.py
+++ b/src/greynoise/util.py
@@ -1,7 +1,9 @@
 """Utility functions."""
 
+import logging
 import os
 import socket
+import sys
 
 import structlog
 from six.moves.configparser import ConfigParser
@@ -10,6 +12,27 @@ CONFIG_FILE = os.path.expanduser(os.path.join("~", ".config", "greynoise", "conf
 LOGGER = structlog.get_logger()
 
 DEFAULT_CONFIG = {"api_key": "", "timeout": 60}
+
+
+def configure_logging():
+    """Configure logging."""
+    logging.basicConfig(stream=sys.stderr, format="%(message)s", level=logging.CRITICAL)
+    logging.getLogger("greynoise").setLevel(logging.WARNING)
+    structlog.configure(
+        processors=[
+            structlog.stdlib.add_logger_name,
+            structlog.stdlib.add_log_level,
+            structlog.stdlib.PositionalArgumentsFormatter(),
+            structlog.processors.TimeStamper(fmt="%Y-%m-%d %H:%M.%S"),
+            structlog.processors.StackInfoRenderer(),
+            structlog.processors.format_exc_info,
+            structlog.dev.ConsoleRenderer(),
+        ],
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
 
 
 def load_config():

--- a/tests/cli/test_init.py
+++ b/tests/cli/test_init.py
@@ -23,7 +23,10 @@ class TestMain(object):
         """Logging is configured."""
         runner = CliRunner()
 
-        with patch("greynoise.cli.configure_logging") as configure_logging:
+        with patch("greynoise.cli.structlog") as structlog, patch(
+            "greynoise.cli.configure_logging"
+        ) as configure_logging:
+            structlog.is_configured.return_value = False
             query_command = Mock()
             with patch.dict(main.commands, query=query_command):
                 runner.invoke(main, ["<parameter>"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,0 @@
-import pytest
-
-from greynoise.cli import configure_logging
-
-
-@pytest.fixture(scope="session", autouse=True)
-def configure_structlog():
-    """Configure logging for test cases."""
-    configure_logging()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -377,6 +377,18 @@ class TestQuery(object):
         client._request.assert_called_with("experimental/gnql", params={"query": query})
         assert response == expected_response
 
+    def test_query_with_size_and_scroll(self, client):
+        """Run GNQL query with size and scroll parameters."""
+        query = "<query>"
+        expected_response = []
+
+        client._request = Mock(return_value=expected_response)
+        response = client.query(query, size=5, scroll="scroll")
+        client._request.assert_called_with(
+            "experimental/gnql", params={"query": query, "size": 5, "scroll": "scroll"}
+        )
+        assert response == expected_response
+
 
 class TestStats(object):
     """GreyNoise client run GNQL stats query test cases."""


### PR DESCRIPTION
Add size and scroll parameters to query method in GreyNoise API object. Also, make sure that logging is properly configured when only the API is used without the CLI.