### PR TITLE
Use advbumpversion

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -15,7 +15,14 @@ replace = __version__ = "{new_version}"
 search = release = "{current_version}"
 replace = release = "{new_version}"
 
-[bumpversion:file:CHANGELOG.rst]
+[bumpversion:file:CHANGELOG.rst:date]
 search = **Date**: unreleased
 replace = **Date**: {now:%B %d, %Y}
 
+[bumpversion:file:CHANGELOG.rst:version]
+search = `dev`
+replace = `{new_version}`
+
+[bumpversion:file:CHANGELOG.rst:version_range]
+search = {current_version}...HEAD
+replace = {current_version}...{new_version}

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,6 +1,6 @@
 # Requirements needed to develop the application
 -r test.txt
-bumpversion==0.5.3
+advbumpversion==1.2.0
 ipython==7.9.0;python_version>='3'
 pre-commit==1.20.0
 tox==3.14.0


### PR DESCRIPTION
Replace `bumpversion` with `advbumpversion` which is a fork (different package name, but same script) that allows to pass multiple search/replace patterns for each file, which is very convenient for the changelog file.