### PR TITLE
Make API server configurable

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,11 +11,13 @@ Version `dev`_
   * add ``filter`` method.
   * add ``analyze`` method.
   * add ``scroll`` and ``size`` parameters to ``query`` method.
+  * add ``api_server`` parameter to ``__init__`` method.
 
 * CLI:
   * add ``interesting`` subcommand.
   * add ``filter`` subcommand.
   * add ``analyze`` subcommand.
+  * add ``api_server`` option to setup subcommand.
 
 * Both API client and CLI:
   * use structlog logging library.

--- a/src/greynoise/api/__init__.py
+++ b/src/greynoise/api/__init__.py
@@ -31,7 +31,6 @@ class GreyNoise(object):
     """
 
     NAME = "GreyNoise"
-    BASE_URL = "https://enterprise.api.greynoise.io"
     API_VERSION = "v2"
     EP_GNQL = "experimental/gnql"
     EP_GNQL_STATS = "experimental/gnql/stats"
@@ -77,14 +76,20 @@ class GreyNoise(object):
         )
     )
 
-    def __init__(self, api_key=None, timeout=None, use_cache=True):
-        if api_key is None or timeout is None:
+    def __init__(self, api_key=None, api_server=None, timeout=None, use_cache=True):
+        if any(
+            configuration_value is None
+            for configuration_value in (api_key, timeout, api_server)
+        ):
             config = load_config()
             if api_key is None:
                 api_key = config["api_key"]
+            if api_server is None:
+                api_server = config["api_server"]
             if timeout is None:
                 timeout = config["timeout"]
         self.api_key = api_key
+        self.api_server = api_server
         self.timeout = timeout
         self.use_cache = use_cache
         self.session = requests.Session()
@@ -111,7 +116,7 @@ class GreyNoise(object):
             "User-Agent": "GreyNoise/{}".format(__version__),
             "key": self.api_key,
         }
-        url = "/".join([self.BASE_URL, self.API_VERSION, endpoint])
+        url = "/".join([self.api_server, self.API_VERSION, endpoint])
         LOGGER.debug(
             "Sending API request...", url=url, method=method, params=params, json=json
         )

--- a/src/greynoise/cli/subcommand.py
+++ b/src/greynoise/cli/subcommand.py
@@ -183,13 +183,21 @@ def quick(
 @click.command()
 @click.option("-k", "--api-key", required=True, help="Key to include in API requests")
 @click.option("-t", "--timeout", type=click.INT, help="API client request timeout")
-def setup(api_key, timeout):
+@click.option("-s", "--api-server", help="API server")
+def setup(api_key, timeout, api_server):
     """Configure API key."""
     config = {"api_key": api_key}
+
     if timeout is None:
         config["timeout"] = DEFAULT_CONFIG["timeout"]
     else:
         config["timeout"] = timeout
+
+    if api_server is None:
+        config["api_server"] = DEFAULT_CONFIG["api_server"]
+    else:
+        config["api_server"] = api_server
+
     save_config(config)
     click.echo("Configuration saved to {!r}".format(CONFIG_FILE))
 

--- a/src/greynoise/util.py
+++ b/src/greynoise/util.py
@@ -11,7 +11,11 @@ from six.moves.configparser import ConfigParser
 CONFIG_FILE = os.path.expanduser(os.path.join("~", ".config", "greynoise", "config"))
 LOGGER = structlog.get_logger()
 
-DEFAULT_CONFIG = {"api_key": "", "timeout": 60}
+DEFAULT_CONFIG = {
+    "api_key": "",
+    "api_server": "https://enterprise.api.greynoise.io",
+    "timeout": 60,
+}
 
 
 def configure_logging():
@@ -65,6 +69,16 @@ def load_config():
         # Environment variable takes precedence over configuration file content
         config_parser.set("greynoise", "api_key", api_key)
 
+    if "GREYNOISE_API_SERVER" in os.environ:
+        api_server = os.environ["GREYNOISE_API_SERVER"]
+        LOGGER.debug(
+            "API server found in environment variable: %s",
+            api_server,
+            api_server=api_server,
+        )
+        # Environment variable takes precedence over configuration file content
+        config_parser.set("greynoise", "api_server", api_server)
+
     if "GREYNOISE_TIMEOUT" in os.environ:
         timeout = os.environ["GREYNOISE_TIMEOUT"]
         try:
@@ -85,6 +99,7 @@ def load_config():
 
     return {
         "api_key": config_parser.get("greynoise", "api_key"),
+        "api_server": config_parser.get("greynoise", "api_server"),
         "timeout": config_parser.getint("greynoise", "timeout"),
     }
 
@@ -100,6 +115,7 @@ def save_config(config):
     config_parser.add_section("greynoise")
     config_parser.set("greynoise", "api_key", config["api_key"])
     config_parser.set("greynoise", "timeout", str(config["timeout"]))
+    config_parser.set("greynoise", "api_server", config["api_server"])
 
     config_dir = os.path.dirname(CONFIG_FILE)
     if not os.path.isdir(config_dir):

--- a/src/greynoise/util.py
+++ b/src/greynoise/util.py
@@ -114,8 +114,8 @@ def save_config(config):
     config_parser = ConfigParser()
     config_parser.add_section("greynoise")
     config_parser.set("greynoise", "api_key", config["api_key"])
-    config_parser.set("greynoise", "timeout", str(config["timeout"]))
     config_parser.set("greynoise", "api_server", config["api_server"])
+    config_parser.set("greynoise", "timeout", str(config["timeout"]))
 
     config_dir = os.path.dirname(CONFIG_FILE)
     if not os.path.isdir(config_dir):

--- a/tests/cli/test_subcommand.py
+++ b/tests/cli/test_subcommand.py
@@ -25,6 +25,7 @@ def api_client():
     with load_config_patcher as load_config:
         load_config.return_value = {
             "api_key": "<api_key>",
+            "api_server": "<api_server>",
             "timeout": DEFAULT_CONFIG["timeout"],
         }
         with api_client_cls_patcher as api_client_cls:
@@ -914,7 +915,11 @@ class TestSetup(object):
         """Save API key to configuration file."""
         runner = CliRunner()
         api_key = "<api_key>"
-        expected_config = {"api_key": api_key, "timeout": DEFAULT_CONFIG["timeout"]}
+        expected_config = {
+            "api_key": api_key,
+            "api_server": DEFAULT_CONFIG["api_server"],
+            "timeout": DEFAULT_CONFIG["timeout"],
+        }
         expected_output = "Configuration saved to {!r}\n".format(CONFIG_FILE)
 
         with patch("greynoise.cli.subcommand.save_config") as save_config:
@@ -924,18 +929,32 @@ class TestSetup(object):
         save_config.assert_called_with(expected_config)
 
     @pytest.mark.parametrize("key_option", ["-k", "--api-key"])
+    @pytest.mark.parametrize("server_option", ["-s", "--api-server"])
     @pytest.mark.parametrize("timeout_option", ["-t", "--timeout"])
-    def test_save_api_key_and_timeout(self, key_option, timeout_option):
+    def test_save_api_key_and_timeout(self, key_option, server_option, timeout_option):
         """Save API key and timeout to configuration file."""
         runner = CliRunner()
         api_key = "<api_key>"
+        api_server = "<api_server>"
         timeout = 123456
-        expected_config = {"api_key": api_key, "timeout": timeout}
+        expected_config = {
+            "api_key": api_key,
+            "api_server": api_server,
+            "timeout": timeout,
+        }
         expected_output = "Configuration saved to {!r}\n".format(CONFIG_FILE)
 
         with patch("greynoise.cli.subcommand.save_config") as save_config:
             result = runner.invoke(
-                subcommand.setup, [key_option, api_key, timeout_option, timeout]
+                subcommand.setup,
+                [
+                    key_option,
+                    api_key,
+                    server_option,
+                    api_server,
+                    timeout_option,
+                    timeout,
+                ],
             )
         assert result.exit_code == 0
         assert result.output == expected_output

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -28,20 +28,30 @@ class TestInit(object):
 
     def test_with_api_key(self):
         """API parameter is passed."""
-        config = {"api_key": "<api_key>", "timeout": "<timeout>"}
+        config = {
+            "api_key": "<api_key>",
+            "api_server": "<api_server>",
+            "timeout": "<timeout>",
+        }
         with patch("greynoise.api.load_config") as load_config:
             client = GreyNoise(**config)
             assert client.api_key == config["api_key"]
+            assert client.api_server == config["api_server"]
             assert client.timeout == config["timeout"]
             load_config.assert_not_called()
 
     def test_without_api_key(self):
         """API parameter is not passed."""
-        config = {"api_key": "<api_key>", "timeout": "<timeout>"}
+        config = {
+            "api_key": "<api_key>",
+            "api_server": "<api_server>",
+            "timeout": "<timeout>",
+        }
         with patch("greynoise.api.load_config") as load_config:
             load_config.return_value = config
             client = GreyNoise()
             assert client.api_key == config["api_key"]
+            assert client.api_server == config["api_server"]
             assert client.timeout == config["timeout"]
             load_config.assert_called()
 

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -83,6 +83,34 @@ class TestLoadConfig(object):
 
     @patch("greynoise.util.open")
     @patch("greynoise.util.os")
+    def test_api_server_from_environment_variable(self, os, open):
+        """API server value retrieved from environment variable."""
+        expected = {
+            "api_key": "<api_key>",
+            "api_server": "<api_server>",
+            "timeout": 123456,
+        }
+
+        os.environ = {"GREYNOISE_API_SERVER": expected["api_server"]}
+        os.path.isfile.return_value = True
+        file_content = textwrap.dedent(
+            """\
+            [greynoise]
+            api_key = {}
+            api_server = unexpected
+            timeout = {}
+            """.format(
+                expected["api_key"], expected["timeout"],
+            )
+        )
+        open().__enter__.return_value = StringIO(file_content)
+
+        config = load_config()
+        assert config == expected
+        open().__enter__.assert_called()
+
+    @patch("greynoise.util.open")
+    @patch("greynoise.util.os")
     def test_timeout_from_environment_variable(self, os, open):
         """Timeout value retrieved from environment variable."""
         expected = {

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -19,13 +19,21 @@ class TestLoadConfig(object):
         os.path.isfile.return_value = False
 
         config = load_config()
-        assert config == {"api_key": "", "timeout": 60}
+        assert config == {
+            "api_key": "",
+            "api_server": "https://enterprise.api.greynoise.io",
+            "timeout": 60,
+        }
 
     @patch("greynoise.util.open")
     @patch("greynoise.util.os")
     def test_values_from_configuration_file(self, os, open):
         """Values retrieved from configuration file."""
-        expected = {"api_key": "<api_key>", "timeout": 123456}
+        expected = {
+            "api_key": "<api_key>",
+            "api_server": "<api_server",
+            "timeout": 123456,
+        }
 
         os.environ = {}
         os.path.isfile.return_value = True
@@ -33,9 +41,10 @@ class TestLoadConfig(object):
             """\
             [greynoise]
             api_key = {}
+            api_server = {}
             timeout = {}
             """.format(
-                expected["api_key"], expected["timeout"]
+                expected["api_key"], expected["api_server"], expected["timeout"],
             )
         )
         open().__enter__.return_value = StringIO(file_content)
@@ -48,7 +57,11 @@ class TestLoadConfig(object):
     @patch("greynoise.util.os")
     def test_api_key_from_environment_variable(self, os, open):
         """API key value retrieved from environment variable."""
-        expected = {"api_key": "<api_key>", "timeout": 123456}
+        expected = {
+            "api_key": "<api_key>",
+            "api_server": "<api_server>",
+            "timeout": 123456,
+        }
 
         os.environ = {"GREYNOISE_API_KEY": expected["api_key"]}
         os.path.isfile.return_value = True
@@ -56,9 +69,10 @@ class TestLoadConfig(object):
             """\
             [greynoise]
             api_key = unexpected
+            api_server = {}
             timeout = {}
             """.format(
-                expected["timeout"]
+                expected["api_server"], expected["timeout"],
             )
         )
         open().__enter__.return_value = StringIO(file_content)
@@ -71,7 +85,11 @@ class TestLoadConfig(object):
     @patch("greynoise.util.os")
     def test_timeout_from_environment_variable(self, os, open):
         """Timeout value retrieved from environment variable."""
-        expected = {"api_key": "<api_key>", "timeout": 123456}
+        expected = {
+            "api_key": "<api_key>",
+            "api_server": "<api_server>",
+            "timeout": 123456,
+        }
 
         os.environ = {"GREYNOISE_TIMEOUT": str(expected["timeout"])}
         os.path.isfile.return_value = True
@@ -79,9 +97,10 @@ class TestLoadConfig(object):
             """\
             [greynoise]
             api_key = {}
+            api_server = {}
             timeout = unexpected
             """.format(
-                expected["api_key"]
+                expected["api_key"], expected["api_server"],
             )
         )
         open().__enter__.return_value = StringIO(file_content)
@@ -94,7 +113,11 @@ class TestLoadConfig(object):
     @patch("greynoise.util.os")
     def test_timeout_from_environment_variable_with_invalid_value(self, os, open):
         """Invalid timeout value in environment variable is ignored."""
-        expected = {"api_key": "<api_key>", "timeout": 123456}
+        expected = {
+            "api_key": "<api_key>",
+            "api_server": "<api_server>",
+            "timeout": 123456,
+        }
 
         os.environ = {"GREYNOISE_TIMEOUT": "invalid"}
         os.path.isfile.return_value = True
@@ -102,9 +125,10 @@ class TestLoadConfig(object):
             """\
             [greynoise]
             api_key = {}
+            api_server = {}
             timeout = {}
             """.format(
-                expected["api_key"], expected["timeout"]
+                expected["api_key"], expected["api_server"], expected["timeout"],
             )
         )
         open().__enter__.return_value = StringIO(file_content)
@@ -119,7 +143,11 @@ class TestSaveConfig(object):
 
     def test_save_config_dir_created(self):
         """Configuration directory created if missing."""
-        config = {"api_key": "<api_key>", "timeout": 123456}
+        config = {
+            "api_key": "<api_key>",
+            "api_server": "<api_server>",
+            "timeout": 123456,
+        }
 
         with patch("greynoise.util.os") as os, patch("greynoise.util.open") as open_:
             os.path.isdir.return_value = False
@@ -131,15 +159,20 @@ class TestSaveConfig(object):
 
     def test_save_config_file_written(self):
         """Configuration written to a file."""
-        config = {"api_key": "<api_key>", "timeout": 123456}
+        config = {
+            "api_key": "<api_key>",
+            "api_server": "<api_server>",
+            "timeout": 123456,
+        }
         expected = textwrap.dedent(
             """\
             [greynoise]
             api_key = {}
+            api_server = {}
             timeout = {}
 
             """.format(
-                config["api_key"], config["timeout"]
+                config["api_key"], config["api_server"], config["timeout"],
             )
         )
 


### PR DESCRIPTION
API server is now configurable using the `setup` command in the CLI, the `GREYNOISE_API_SERVER` environment variable or by passing the `api_server` parameter to `GreyNoise.__init__`.