### PR TITLE
Add metadata endpoint

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.1
+current_version = 0.4.2
 tag = True
 commit = True
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+Version `dev`_
+================
+**Date**: unreleased
+
+* API client:
+  * add ``metadata`` method.
+
+
 Version `0.4.1`_
 ================
 **Date**: Jan 3, 2020

--- a/src/greynoise/api/__init__.py
+++ b/src/greynoise/api/__init__.py
@@ -37,6 +37,7 @@ class GreyNoise(object):
     EP_INTERESTING = "interesting/{ip_address}"
     EP_NOISE_MULTI = "noise/multi/quick"
     EP_NOISE_CONTEXT = "noise/context/{ip_address}"
+    EP_META_METADATA = "meta/metadata"
     EP_NOT_IMPLEMENTED = "request/{subcommand}"
     UNKNOWN_CODE_MESSAGE = "Code message unknown: {}"
     CODE_MESSAGES = {
@@ -332,4 +333,10 @@ class GreyNoise(object):
         if count is not None:
             params["count"] = count
         response = self._request(self.EP_GNQL_STATS, params=params)
+        return response
+
+    def metadata(self):
+        """Get metadata."""
+        LOGGER.debug("Getting metadata...")
+        response = self._request(self.EP_META_METADATA)
         return response

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -303,7 +303,10 @@ class TestFilter(object):
                 "0.0.0.0\n255.255.255.255\nnot an ip address",
                 "<noise>0.0.0.0</noise>\n",
             ),
-            ("0.0.0.0 255.255.255.255\nnot an ip address", "",),
+            (
+                "0.0.0.0 255.255.255.255\nnot an ip address",
+                "",
+            ),
         ],
     )
     def test_select_noise(self, client, text, expected_output):
@@ -640,4 +643,17 @@ class TestStats(object):
         client._request.assert_called_with(
             "experimental/gnql/stats", params={"query": query}
         )
+        assert response == expected_response
+
+
+class TestMeta(object):
+    """GreyNoise client run GNQL stats query test cases."""
+
+    def test_metadata(self, client):
+        """Run GNQL stats query."""
+        expected_response = []
+
+        client._request = Mock(return_value=expected_response)
+        response = client.metadata()
+        client._request.assert_called_with("meta/metadata")
         assert response == expected_response


### PR DESCRIPTION
Add `metadata` method for accessing the `/meta/metadata` endpoint.