### PR TITLE
Update XML formatter to use dict2xml

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.2
+current_version = 0.4.3
 tag = True
 commit = True
 

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -6,7 +6,7 @@ ansimarkup==1.4.0
 cachetools==3.1.1
 click-default-group==1.2.2
 click-repl==0.1.6
-dicttoxml==1.7.4
+dict2xml==1.7.0
 jinja2==2.11.1
 requests==2.22.0
 six==1.13.0

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -6,7 +6,7 @@ ansimarkup==1.4.0
 cachetools==3.1.1
 click-default-group==1.2.2
 click-repl==0.1.6
-dict2xml==1.7.0
+dict2xml==1.6.1
 jinja2==2.11.1
 requests==2.22.0
 six==1.13.0

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ INSTALL_REQUIRES = [
     "cachetools",
     "click-default-group",
     "click-repl",
-    "dicttoxml",
+    "dict2xml",
     "jinja2",
     "more-itertools",
     "requests",

--- a/src/greynoise/cli/formatter.py
+++ b/src/greynoise/cli/formatter.py
@@ -57,9 +57,14 @@ def json_formatter(result, _verbose):
 
 def xml_formatter(result, _verbose):
     """Format result as xml."""
-    xml_formatted = dict2xml({"item": result}, wrap='root', indent="   ")
+    xml_formatted = ""
+    if type(result) is list:
+        xml_formatted = dict2xml({"item": result}, wrap="root", indent="\t")
+    else:
+        xml_formatted = dict2xml(result, wrap="root", indent="   ")
+
     # dict2xml does not add header, so add header manually
-    xml_header = '<?xml version="1.0"?>'
+    xml_header = '<?xml version="1.0" ?>'
     return "{}\n{}".format(xml_header, xml_formatted)
 
 

--- a/src/greynoise/cli/formatter.py
+++ b/src/greynoise/cli/formatter.py
@@ -5,12 +5,11 @@ from __future__ import print_function
 
 import functools
 import json
-from xml.dom.minidom import parseString
 
 import ansimarkup
 import click
 import colorama
-from dicttoxml import dicttoxml
+from dict2xml import dict2xml
 from jinja2 import Environment, PackageLoader, select_autoescape
 
 JINJA2_ENV = Environment(
@@ -58,7 +57,10 @@ def json_formatter(result, _verbose):
 
 def xml_formatter(result, _verbose):
     """Format result as xml."""
-    return parseString(dicttoxml(result)).toprettyxml()
+    xml_formatted = dict2xml({"item": result}, wrap='root', indent="   ")
+    # dict2xml does not add header, so add header manually
+    xml_header = '<?xml version="1.0"?>'
+    return "{}\n{}".format(xml_header, xml_formatted)
 
 
 def get_location(metadata):

--- a/tests/cli/test_formatter.py
+++ b/tests/cli/test_formatter.py
@@ -115,11 +115,10 @@ class TestXMLFormatter(object):
         """Format to xml."""
         assert xml_formatter({"a": "result"}, _verbose=False) == textwrap.dedent(
             """\
-            <?xml version="1.0"?>
+            <?xml version="1.0" ?>
             <root>
-            \t<a type="str">result</a>
-            </root>
-            """
+               <a>result</a>
+            </root>"""
         )
 
 

--- a/tests/cli/test_formatter.py
+++ b/tests/cli/test_formatter.py
@@ -115,7 +115,7 @@ class TestXMLFormatter(object):
         """Format to xml."""
         assert xml_formatter({"a": "result"}, _verbose=False) == textwrap.dedent(
             """\
-            <?xml version="1.0" ?>
+            <?xml version="1.0"?>
             <root>
             \t<a type="str">result</a>
             </root>

--- a/tests/cli/test_subcommand.py
+++ b/tests/cli/test_subcommand.py
@@ -732,9 +732,9 @@ class TestQuick(object):
                     """\
                     <?xml version="1.0" ?>
                     <root>
-                    \t<item type="dict">
-                    \t\t<ip type="str">0.0.0.0</ip>
-                    \t\t<noise type="bool">True</noise>
+                    \t<item>
+                    \t\t<ip>0.0.0.0</ip>
+                    \t\t<noise>True</noise>
                     \t</item>
                     </root>"""
                 ),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -303,10 +303,7 @@ class TestFilter(object):
                 "0.0.0.0\n255.255.255.255\nnot an ip address",
                 "<noise>0.0.0.0</noise>\n",
             ),
-            (
-                "0.0.0.0 255.255.255.255\nnot an ip address",
-                "",
-            ),
+            ("0.0.0.0 255.255.255.255\nnot an ip address", "",),
         ],
     )
     def test_select_noise(self, client, text, expected_output):


### PR DESCRIPTION
Fixes #359

The library `dict2xml` uses an MIT license

#### Summary of changes
* Change XML formatting library from `dicttoxml` to `dict2xml1`. The later is not as sophisticated as the first but does produce valid XML and should be sufficient for our requirements.
* Slight change in the way arrays are formatted between the 2 library. 

##### CLI Usage (docker)
![image](https://user-images.githubusercontent.com/3009118/101696681-77fa1f80-3a44-11eb-904f-e3b8ff7b023f.png)
