### PR TITLE
Use compatible version for python2 but keep python3 at latest for dic…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Version `dev`_
 
 * API client:
   * add ``metadata`` method.
-
+  * replace `dicttoxml` with `dict2xml` for license-compatibility.
 
 Version `0.4.1`_
 ================

--- a/requirements/common-py2.txt
+++ b/requirements/common-py2.txt
@@ -2,3 +2,4 @@
 # packages in this file are not pinned to their latest version
 # because python2 is no longer supported
 more-itertools==5.0.0;python_version<'3'
+dict2xml==1.6.1;python_version<'3'

--- a/requirements/common-py3.txt
+++ b/requirements/common-py3.txt
@@ -1,1 +1,2 @@
 more-itertools==8.1.0;python_version>='3'
+dict2xml==1.7.0;python_version>='3'

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -6,7 +6,6 @@ ansimarkup==1.4.0
 cachetools==3.1.1
 click-default-group==1.2.2
 click-repl==0.1.6
-dict2xml==1.6.1
 jinja2==2.11.1
 requests==2.22.0
 six==1.13.0


### PR DESCRIPTION
…t2xml

### Summary
Since we differentiate library versions for Python2 vs Python3, I've pinned `dict2xml` to a Python2-compatible version for the code but use latest version for Python3. 
The main goal is to keep the Python2 version pinned as later versions are not compatible. No reason to keep Python3 on older version. 
