### PR TITLE
Add rst linter to circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,6 +89,9 @@ jobs:
           name: Style check (isort)
           command: isort --check-only setup.py src/**/*.py tests/**/*.py docs/**/*.py
       - run:
+          name: Style check (rst)
+          command: rst-lint *.rst
+      - run:
           name: Static analysis (flake8)
           command: flake8 setup.py src tests docs
       - run:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -117,4 +117,4 @@ Version `0.2.0`_
 .. _`0.4.0`: https://github.com/GreyNoise-Intelligence/pygreynoise/compare/v0.3.0...0.4.0
 .. _`0.4.1`: https://github.com/GreyNoise-Intelligence/pygreynoise/compare/v0.4.0...0.4.1
 .. _`0.5.0`: https://github.com/GreyNoise-Intelligence/pygreynoise/compare/v0.4.1...0.5.0
-#.. _`dev`: https://github.com/GreyNoise-Intelligence/pygreynoise/compare/v0.5.0...master
+.. _`dev`: https://github.com/GreyNoise-Intelligence/pygreynoise/compare/v0.5.0...HEAD

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,15 +2,33 @@
 Changelog
 =========
 
+Version `dev`_
+================
+**Date**: unreleased
+
+* API client:
+
+  * 1
+
+* CLI:
+
+  * 1
+
+* Both API client and CLI:
+
+  * 1
+
 Version `0.5.0`_
 ================
 **Date**: December 16, 2020
 
 * API client:
+
   * add ``metadata`` method.
   * replace `dicttoxml` with `dict2xml` for license-compatibility.
 
 * Both API client and CLI:
+
   * Update dependencies to the latest version
   * Add support for PROXY usage
   * Update the IP validator to ensure better validation
@@ -20,6 +38,7 @@ Version `0.4.1`_
 **Date**: January 3, 2020
 
 * API client:
+
   * add ``spoofable`` field.
 
 Version `0.4.0`_
@@ -27,6 +46,7 @@ Version `0.4.0`_
 **Date**: November 18, 2019
 
 * API client:
+
   * add ``interesting`` method.
   * add ``filter`` method.
   * add ``analyze`` method.
@@ -34,6 +54,7 @@ Version `0.4.0`_
   * add ``api_server`` and ``integration_name`` parameters to ``__init__`` method.
 
 * CLI:
+
   * add ``interesting`` subcommand.
   * add ``filter`` subcommand.
   * add ``analyze`` subcommand.
@@ -62,7 +83,9 @@ Version `0.2.2`_
 ================
 **Date**: August 28, 2019
 
-* CLI: fix ``setup`` subcommand when configuration directory doesn't exist.
+* CLI:
+
+  * fix ``setup`` subcommand when configuration directory doesn't exist.
 
 
 Version `0.2.1`_
@@ -94,3 +117,4 @@ Version `0.2.0`_
 .. _`0.4.0`: https://github.com/GreyNoise-Intelligence/pygreynoise/compare/v0.3.0...0.4.0
 .. _`0.4.1`: https://github.com/GreyNoise-Intelligence/pygreynoise/compare/v0.4.0...0.4.1
 .. _`0.5.0`: https://github.com/GreyNoise-Intelligence/pygreynoise/compare/v0.4.1...0.5.0
+#.. _`dev`: https://github.com/GreyNoise-Intelligence/pygreynoise/compare/v0.5.0...master

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -5,3 +5,4 @@
 flake8==3.8.4
 pytest-cov==2.10.1
 yamllint==1.25.0
+restructuredtext-lint==1.3.2


### PR DESCRIPTION
- Added rst-lint to circleci to lint all RST files in the root of the project (specifically the README and CHANGLOG) to ensure compatibility with PyPi
- Also added back missing placeholders to CHANGELOG.rst for bumpversion and fixed some formatting issues.

Fixes #372 