### PR TITLE
Make cache limits configurable instead of hard-coded

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,7 @@ Version `dev`_
   * Added support for new /riot endpoint
   * Updated logic in quick to better handle non-list format input ('ip_1,ip_2')instead of
     ['ip_1','ip_2']
+  * Added ability to configure CACHE TTL and CACHE MAX SIZE instead of only using hardcoded defaults
 
 * CLI:
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -12,7 +12,7 @@ Python GreyNoise
 
 License
 =======
-Copyright 2018-2020 GreyNoise Intelligence
+Copyright 2018-2021 GreyNoise Intelligence
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -15,4 +15,4 @@ In particular, it will allow you to:
 
 - get a list of noise IP address found in a given date.
 
-.. _GreyNoise API: http://dev.greynoise.io:8000/
+.. _GreyNoise API: https://developer.greynoise.io/reference

--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -11,13 +11,16 @@ Create client object
 To interact with the API, a client object needs to be created::
 
    >>> from greynoise import GreyNoise
-   >>> api_client = GreyNoise(api_key=<api_key>, timeout=<timeout_in_seconds>, proxy=<proxy_url>)
+   >>> api_client = GreyNoise(api_key=<api_key>, timeout=<timeout_in_seconds>, proxy=<proxy_url>, use_cache=True, cache_max_size=1000, cache_ttl=3600)
 
 where:
 
 - *api_key* is the key you have been given to use the API.
 - *timeout_in_seconds* is the timeout for each request sent to the API.
 - *proxy* is the url (ex `http://myproxy.corp.io:1234`) for requests to be routed through.
+- *use_cache* is used to disable (enabled by default) use of local cache for lookups.
+- *cache_max_size* is used to define the max size of the cache, if enabled.
+- *cache_ttl* is used to define the TTL of the data in the cache, if enabled.
 
 .. note::
 
@@ -82,6 +85,7 @@ output they can be checked all at once like this::
       "code": "404",
       "code_message": "IP is Invalid"}
     ]
+
 Detailed context information for any given IP address is also available::
 
     >>> api_client.ip('58.220.219.247')

--- a/src/greynoise/api/__init__.py
+++ b/src/greynoise/api/__init__.py
@@ -20,6 +20,7 @@ LOGGER = structlog.get_logger()
 
 
 def initialize_cache(cache_max_size, cache_ttl):
+    """A function to initialize cache"""
     cache = cachetools.TTLCache(maxsize=cache_max_size, ttl=cache_ttl)
     return cache
 
@@ -122,8 +123,9 @@ class GreyNoise(object):
             cache_max_size = 1000
         self.cache_max_size = cache_max_size
 
-        self.ip_quick_check_cache = initialize_cache(cache_max_size, cache_ttl)
-        self.ip_context_cache = initialize_cache(cache_max_size, cache_ttl)
+        if use_cache:
+            self.ip_quick_check_cache = initialize_cache(cache_max_size, cache_ttl)
+            self.ip_context_cache = initialize_cache(cache_max_size, cache_ttl)
 
     def _request(self, endpoint, params=None, json=None, method="get"):
         """Handle the requesting of information from the API.

--- a/src/greynoise/api/__init__.py
+++ b/src/greynoise/api/__init__.py
@@ -19,6 +19,11 @@ if not structlog.is_configured():
 LOGGER = structlog.get_logger()
 
 
+def initialize_cache(cache_max_size, cache_ttl):
+    cache = cachetools.TTLCache(maxsize=cache_max_size, ttl=cache_ttl)
+    return cache
+
+
 class GreyNoise(object):
 
     """GreyNoise API client.
@@ -109,20 +114,16 @@ class GreyNoise(object):
         self.integration_name = integration_name
         self.session = requests.Session()
 
-        if cache_ttl is None:
+        if cache_ttl is None or not isinstance(cache_ttl, int):
             cache_ttl = 3600
         self.cache_ttl = cache_ttl
 
-        if cache_max_size is None:
+        if cache_max_size is None or not isinstance(cache_max_size, int):
             cache_max_size = 1000
         self.cache_max_size = cache_max_size
 
-        self.ip_quick_check_cache = cachetools.TTLCache(
-            maxsize=cache_max_size, ttl=cache_ttl
-        )
-        self.ip_context_cache = cachetools.TTLCache(
-            maxsize=cache_max_size, ttl=cache_ttl
-        )
+        self.ip_quick_check_cache = initialize_cache(cache_max_size, cache_ttl)
+        self.ip_context_cache = initialize_cache(cache_max_size, cache_ttl)
 
     def _request(self, endpoint, params=None, json=None, method="get"):
         """Handle the requesting of information from the API.

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,8 +12,6 @@ from greynoise.exceptions import RateLimitError, RequestFailure
 def client():
     """API client fixture."""
     client = GreyNoise(api_key="<api_key>", integration_name="test")
-#    client.IP_QUICK_CHECK_CACHE.clear()
-#    client.IP_CONTEXT_CACHE.clear()
     yield client
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,8 +12,8 @@ from greynoise.exceptions import RateLimitError, RequestFailure
 def client():
     """API client fixture."""
     client = GreyNoise(api_key="<api_key>", integration_name="test")
-    client.IP_QUICK_CHECK_CACHE.clear()
-    client.IP_CONTEXT_CACHE.clear()
+#    client.IP_QUICK_CHECK_CACHE.clear()
+#    client.IP_CONTEXT_CACHE.clear()
     yield client
 
 


### PR DESCRIPTION
Fixes #385 

```
from greynoise import GreyNoise

api_client = GreyNoise(api_key='<key>',cache_ttl=10,cache_max_size=10)
```