### PR TITLE
[FIX] added two virtualenv-specific artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -90,6 +90,8 @@ venv/
 venv_py2/
 venv3/
 ENV/
+bin/
+pyvenv.cfg
 
 # Spyder project settings
 .spyderproject


### PR DESCRIPTION
added two artifacts specific to `virtualenv` that were not in `.gitignore`:

- `bin/` directory
- `pyenv.cfg`