### PR TITLE
deprecate stale subcommand

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,6 @@ Usage
       help         Show this message and exit.
       interesting  Report an IP as "interesting".
       ip           Query GreyNoise for all information on a given IP.
-      pcap         Get PCAP for a given IP address.
       quick        Quickly check whether or not one or many IPs are "noise".
       repl         Start an interactive shell.
       setup        Configure API key.

--- a/src/greynoise/cli/subcommand.py
+++ b/src/greynoise/cli/subcommand.py
@@ -180,11 +180,6 @@ def riot(
     return results
 
 
-@not_implemented_command
-def pcap():
-    """Get PCAP for a given IP address."""
-
-
 @gnql_command
 def query(
     context,

--- a/tests/cli/test_subcommand.py
+++ b/tests/cli/test_subcommand.py
@@ -635,21 +635,6 @@ class TestIP(object):
             assert "Error: API key not found" in result.output
 
 
-class TestPCAP(object):
-    """PCAP subcommand test cases."""
-
-    def test_not_implemented(self, api_client):
-        """Not implemented error message returned."""
-        runner = CliRunner()
-        expected_output = "Error: 'pcap' subcommand is not implemented yet.\n"
-
-        api_client.not_implemented.side_effect = RequestFailure(501)
-        result = runner.invoke(subcommand.pcap)
-        api_client.not_implemented.assert_called_with("pcap")
-        assert result.exit_code == 1
-        assert result.output == expected_output
-
-
 class TestQuery(object):
     """Query subcommand tests."""
 


### PR DESCRIPTION
This removes stale subcommand from CLI

PoW

```
lab $ ./virtme/bin/greynoise                                           
Usage: greynoise [OPTIONS] COMMAND [ARGS]...

  GreyNoise CLI.

Options:
  -h, --help  Show this message and exit.

Commands:
  account      View information about your GreyNoise account.
  alerts       List, create, delete, and manage your GreyNoise alerts.
  analyze      Analyze the IP addresses in a log file, stdin, etc.
  feedback     Send feedback directly to the GreyNoise team.
  filter       Filter the noise from a log file, stdin, etc.
  help         Show this message and exit.
  interesting  Report one or more IP addresses as "interesting".
  ip           Query GreyNoise for all information on a given IP.
  ip-multi     Perform Context lookup for multiple IPs at once.
  query        Run a GNQL (GreyNoise Query Language) query.
  quick        Quickly check whether or not one or many IPs are "noise".
  repl         Start an interactive shell.
  riot         Query GreyNoise IP to see if it is in the RIOT dataset.
  setup        Configure API key.
  signature    Submit an IDS signature to GreyNoise to be deployed to all...
  stats        Get aggregate stats from a given GNQL query.
  version      Get version and OS information for your GreyNoise...
```