### PR TITLE
Add `greynoiselabs` wrapper for `labs` subcommand

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,7 +5,7 @@ colorama==0.4.6
 click-default-group==1.2.2
 click-repl==0.2.0
 dict2xml==1.7.3;python_version>='3'
-greynoiselabs>=1.24.0
+greynoiselabs>=1.25.0
 ipaddress==1.0.23
 jinja2==3.1.2;python_version>='3.6'
 more-itertools==9.1.0;python_version>='3'

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,8 +5,10 @@ colorama==0.4.6
 click-default-group==1.2.2
 click-repl==0.2.0
 dict2xml==1.7.3;python_version>='3'
+greynoiselabs>=1.24.0
 ipaddress==1.0.23
 jinja2==3.1.2;python_version>='3.6'
 more-itertools==9.1.0;python_version>='3'
 requests==2.28.2
 six==1.16.0
+typer==0.9.0

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,7 +5,7 @@ colorama==0.4.6
 click-default-group==1.2.2
 click-repl==0.2.0
 dict2xml==1.7.3;python_version>='3'
-greynoiselabs==1.25.0
+greynoiselabs==0.1.25
 ipaddress==1.0.23
 jinja2==3.1.2;python_version>='3.6'
 more-itertools==9.1.0;python_version>='3'

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,7 +5,7 @@ colorama==0.4.6
 click-default-group==1.2.2
 click-repl==0.2.0
 dict2xml==1.7.3;python_version>='3'
-greynoiselabs==0.1.25
+greynoiselabs==0.1.25;python_version>='3.7.2'
 ipaddress==1.0.23
 jinja2==3.1.2;python_version>='3.6'
 more-itertools==9.1.0;python_version>='3'

--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,7 +5,7 @@ colorama==0.4.6
 click-default-group==1.2.2
 click-repl==0.2.0
 dict2xml==1.7.3;python_version>='3'
-greynoiselabs>=1.25.0
+greynoiselabs==1.25.0
 ipaddress==1.0.23
 jinja2==3.1.2;python_version>='3.6'
 more-itertools==9.1.0;python_version>='3'

--- a/setup.py
+++ b/setup.py
@@ -19,11 +19,14 @@ INSTALL_REQUIRES = [
     "click-default-group",
     "click-repl",
     "dict2xml",
+    "greynoiselabs",
     "ipaddress",
     "jinja2",
     "more-itertools",
     "requests",
     "six",
+    "typer",
+    
 ]
 
 setup(

--- a/src/greynoise/cli/__init__.py
+++ b/src/greynoise/cli/__init__.py
@@ -1,9 +1,12 @@
 """GreyNoise command line Interface."""
 
 import click
+import typer
+
 from click_default_group import DefaultGroup
 from click_repl import register_repl
 
+from greynoiselabs.cli import app
 from greynoise.cli import subcommand
 
 
@@ -24,5 +27,8 @@ SUBCOMMAND_FUNCTIONS = [
 
 for subcommand_function in SUBCOMMAND_FUNCTIONS:
     main.add_command(subcommand_function)
+
+typer_click_object = typer.main.get_command(app)
+main.add_command(typer_click_object, "labs")
 
 register_repl(main)

--- a/src/greynoise/cli/__init__.py
+++ b/src/greynoise/cli/__init__.py
@@ -2,11 +2,11 @@
 
 import click
 import typer
+import platform
 
 from click_default_group import DefaultGroup
 from click_repl import register_repl
 
-from greynoiselabs.cli import app
 from greynoise.cli import subcommand
 
 
@@ -28,7 +28,9 @@ SUBCOMMAND_FUNCTIONS = [
 for subcommand_function in SUBCOMMAND_FUNCTIONS:
     main.add_command(subcommand_function)
 
-typer_click_object = typer.main.get_command(app)
-main.add_command(typer_click_object, "labs")
+if platform.python_version() >= "3.7.2":
+    from greynoiselabs.cli import app
+    typer_click_object = typer.main.get_command(app)
+    main.add_command(typer_click_object, "labs")
 
 register_repl(main)

--- a/src/greynoise/cli/__init__.py
+++ b/src/greynoise/cli/__init__.py
@@ -7,6 +7,7 @@ import platform
 from click_default_group import DefaultGroup
 from click_repl import register_repl
 
+from greynoise.cli.decorator import not_implemented_command
 from greynoise.cli import subcommand
 
 
@@ -32,5 +33,11 @@ if platform.python_version() >= "3.7.2":
     from greynoiselabs.cli import app
     typer_click_object = typer.main.get_command(app)
     main.add_command(typer_click_object, "labs")
+else: 
+    @not_implemented_command
+    def labs():
+        """GreyNoise Labs CLI wrapper."""
+
+    main.add_command(labs, "labs")
 
 register_repl(main)

--- a/src/greynoise/cli/subcommand.py
+++ b/src/greynoise/cli/subcommand.py
@@ -24,7 +24,6 @@ from greynoise.util import CONFIG_FILE, DEFAULT_CONFIG, save_config
 def account():
     """View information about your GreyNoise account."""
 
-
 @not_implemented_command
 def alerts():
     """List, create, delete, and manage your GreyNoise alerts."""


### PR DESCRIPTION
This adds a very thin wrapper for the `greynoiselabs` as `greynoise labs` so people can start to use the experimental labs stuff within the normal `greynoise` CLI. Currently, secondary auth is required. However, eventually this will be a seamless single sign-on experience. 

See [Including Typer as a Click subcommand.](https://typer.tiangolo.com/tutorial/using-click/#including-a-typer-app-in-a-click-app)