### PR TITLE
drop ipaddress from requirements

### DIFF
--- a/requirements/common.txt
+++ b/requirements/common.txt
@@ -5,7 +5,6 @@ colorama==0.4.6
 click-default-group==1.2.2
 click-repl==0.2.0
 dict2xml==1.7.3;python_version>='3'
-ipaddress==1.0.23
 jinja2==3.1.2;python_version>='3.6'
 more-itertools==9.1.0;python_version>='3'
 requests==2.28.2

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,6 @@ INSTALL_REQUIRES = [
     "click-default-group",
     "click-repl",
     "dict2xml",
-    "ipaddress",
     "jinja2",
     "more-itertools",
     "requests",


### PR DESCRIPTION
As python 2 support is officially discontinued and minimal supported python version is 3.6, it is safe to drop `ipaddress` dependency, as it is builtin